### PR TITLE
Add a way to filter upgrades on current day in upgrade planner

### DIFF
--- a/ElectronicObserver/App.xaml.cs
+++ b/ElectronicObserver/App.xaml.cs
@@ -324,12 +324,16 @@ public partial class App : Application
 		tracker
 			.Configure<EquipmentUpgradePlanViewerViewModel>()
 			.Property(w => w.Filters.DisplayFinished)
+			.Property(w => w.Filters.SelectAllDay)
+			.Property(w => w.Filters.SelectToday)
 			.Property(w => w.ColumnProperties)
 			.Property(w => w.SortDescriptions);
 
 		tracker
 			.Configure<EquipmentUpgradePlannerWindow>()
 			.Property(w => w.ViewModel.Filters.DisplayFinished)
+			.Property(w => w.ViewModel.Filters.SelectAllDay)
+			.Property(w => w.ViewModel.Filters.SelectToday)
 			.Property(w => w.ViewModel.CompactMode)
 			.Property(w => w.ViewModel.PlanListWidth);
 

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterDayViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterDayViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using ElectronicObserver.Common;
+using ElectronicObserver.Utility;
 
 namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner;
 
@@ -8,7 +9,7 @@ public class EquipmentUpgradeFilterDayViewModel : CheckBoxEnumViewModel
 {
 	public EquipmentUpgradeFilterDayViewModel(Enum value) : base(value)
 	{
-
+		Configuration.Instance.ConfigurationChanged += () => OnPropertyChanged("");
 	}
 
 	public string DisplayValue => CultureInfo.CurrentCulture.Name switch

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterViewModel.cs
@@ -58,7 +58,6 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 
 		PropertyChanged += (sender, args) =>
 		{
-			// On selected day change
 			if (args.PropertyName is not nameof(SelectedDay)) return;
 
 			foreach (CheckBoxEnumViewModel format in Days)
@@ -103,7 +102,7 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 
 	private void UpdateUpgradeDay()
 	{
-		// Since the views are subscibed to property changed of this viewmodel, just changing this property should be enough to refresh data
+		// Since the views are subscribed to property changed of this viewmodel, just changing this property should be enough to refresh data
 		Today = DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek;
 	}
 

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterViewModel.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using ElectronicObserver.Common;
+using ElectronicObserver.Utility;
+using ElectronicObserver.Utility.Mathematics;
 using ElectronicObserver.Window.Tools.EquipmentUpgradePlanner.Helpers;
 
 namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner;
@@ -16,6 +19,19 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 
 	public DayOfWeek? SelectedDay { get; set; }
 	public bool SelectAllDay { get; set; }
+
+	public bool SelectToday { get; set; }
+
+	public DayOfWeek Today { get; set; }
+
+	public EquipmentUpgradePlannerTranslationViewModel Translations { get; set; } = new();
+
+	public string TodayDisplay => string.Format(Translations.Today, CultureInfo.CurrentCulture.Name switch
+	{
+		"ja-JP" => CultureInfo.CurrentCulture.DateTimeFormat.GetDayName(Today)[..1],
+		_ => CultureInfo.CurrentCulture.DateTimeFormat.GetDayName(Today)[..3],
+	});
+
 
 	public EquipmentUpgradeFilterViewModel()
 	{
@@ -31,6 +47,7 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 				if (isChecked)
 				{
 					SelectedDay = dayValue;
+					SelectToday = false;
 				}
 				else if (SelectedDay == dayValue)
 				{
@@ -41,6 +58,7 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 
 		PropertyChanged += (sender, args) =>
 		{
+			// On selected day change
 			if (args.PropertyName is not nameof(SelectedDay)) return;
 
 			foreach (CheckBoxEnumViewModel format in Days)
@@ -50,25 +68,56 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 				format.IsChecked = dayValue == SelectedDay;
 			}
 
-			SelectAllDay = SelectedDay is null;
+			SelectAllDay = SelectedDay is null && !SelectToday;
 		};
 
 		PropertyChanged += (sender, args) =>
 		{
 			if (args.PropertyName is not nameof(SelectAllDay)) return;
 
+			if (SelectAllDay) SelectToday = false;
+			else if (SelectedDay is null && !SelectToday) SelectAllDay = true;
+
 			if (SelectAllDay) SelectedDay = null;
-			else if (SelectedDay is null) SelectAllDay = true;
 		};
 
-		SelectedDay = TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.Today, "Tokyo Standard Time").DayOfWeek;
+		PropertyChanged += (sender, args) =>
+		{
+			if (args.PropertyName is not nameof(SelectToday)) return;
+
+			if (SelectToday)
+			{
+				SelectAllDay = false;
+				SelectedDay = null;
+			}
+
+			SelectAllDay = SelectedDay is null && !SelectToday;
+		};
+
+		SelectedDay = DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek;
+
+		SystemEvents.UpdateTimerTick += UpdateUpgradeDay;
+
+		Configuration.Instance.ConfigurationChanged += () => OnPropertyChanged(nameof(TodayDisplay));
+	}
+
+	private void UpdateUpgradeDay()
+	{
+		// Since the views are subscibed to property changed of this viewmodel, just changing this property should be enough to refresh data
+		Today = DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek;
 	}
 
 	public bool MeetsFilterCondition(EquipmentUpgradePlanItemViewModel plan)
 	{
 		if (!DisplayFinished && plan.Finished) return false;
 
-		if (SelectedDay is DayOfWeek selectedDay)
+		DayOfWeek? dayFilter = SelectToday switch
+		{
+			true => Today,
+			_ => SelectedDay
+		};
+
+		if (dayFilter is DayOfWeek selectedDay)
 		{
 			List<DayOfWeek> daysOfThePlan = plan.HelperViewModels
 				.SelectMany(helpers => helpers.Days)

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradeFilterViewModel.cs
@@ -93,7 +93,7 @@ public class EquipmentUpgradeFilterViewModel : ObservableObject
 			SelectAllDay = SelectedDay is null && !SelectToday;
 		};
 
-		SelectedDay = DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek;
+		SelectToday = true;
 
 		SystemEvents.UpdateTimerTick += UpdateUpgradeDay;
 

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlanner.Designer.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlanner.Designer.cs
@@ -205,6 +205,15 @@ namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 本日 ({0}).
+        /// </summary>
+        public static string Today {
+            get {
+                return ResourceManager.GetString("Today", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 総計必要資材.
         /// </summary>
         public static string TotalCost {

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlanner.en.resx
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlanner.en.resx
@@ -177,4 +177,7 @@
   <data name="All" xml:space="preserve">
     <value>All</value>
   </data>
+  <data name="Today" xml:space="preserve">
+    <value>Today ({0})</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlanner.resx
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlanner.resx
@@ -177,4 +177,7 @@
   <data name="All" xml:space="preserve">
     <value>全て</value>
   </data>
+  <data name="Today" xml:space="preserve">
+    <value>本日 ({0})</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlannerTranslationViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlannerTranslationViewModel.cs
@@ -1,5 +1,7 @@
-﻿namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner;
-public class EquipmentUpgradePlannerTranslationViewModel
+﻿using ElectronicObserver.ViewModels.Translations;
+
+namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner;
+public class EquipmentUpgradePlannerTranslationViewModel : TranslationBaseViewModel
 {
 	public string Goal => EquipmentUpgradePlanner.Goal;
 	public string IsFinished => EquipmentUpgradePlanner.IsFinished;
@@ -20,4 +22,5 @@ public class EquipmentUpgradePlannerTranslationViewModel
 	public string Required => EquipmentUpgradePlanner.Required;
 	public string TotalCost => EquipmentUpgradePlanner.TotalCost;
 	public string CompactMode => EquipmentUpgradePlanner.CompactMode;
+	public string Today => EquipmentUpgradePlanner.Today;
 }

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlannerWindow.xaml
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/EquipmentUpgradePlannerWindow.xaml
@@ -353,11 +353,9 @@
 				BorderThickness="1"
 				/>
 
-			<CheckBox
-				Margin="10 0 0 0"
-				Content="{Binding EquipmentUpgradePlanner.All}"
-				IsChecked="{Binding Filters.SelectAllDay}"
-				/>
+			<CheckBox Content="{Binding Filters.TodayDisplay}" IsChecked="{Binding Filters.SelectToday}" />
+
+			<CheckBox Content="{Binding EquipmentUpgradePlanner.All}" IsChecked="{Binding Filters.SelectAllDay}" />
 
 			<ItemsControl ItemsSource="{Binding Filters.Days}">
 

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/Helpers/EquipmentUpgradeDayViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/Helpers/EquipmentUpgradeDayViewModel.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Windows.Media;
 using ElectronicObserver.Data;
+using ElectronicObserver.Utility.Mathematics;
 using ElectronicObserverTypes;
 
 namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner.Helpers;
@@ -34,7 +35,7 @@ public class EquipmentUpgradeDayViewModel
 
 		BackgroundColor = helpers.Any() switch
 		{
-			true => day == TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.Today, "Tokyo Standard Time").DayOfWeek ? Color.FromArgb(255, 30, 142, 255) : Color.FromArgb(153, 65, 65, 247),
+			true => day == DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek ? Color.FromArgb(255, 30, 142, 255) : Color.FromArgb(153, 65, 65, 247),
 			_ => Color.FromArgb(0, 0, 0, 0),
 		};
 	}

--- a/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/Helpers/EquipmentUpgradeHelpersDayViewModel.cs
+++ b/ElectronicObserver/Window/Tools/EquipmentUpgradePlanner/Helpers/EquipmentUpgradeHelpersDayViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Media;
+using ElectronicObserver.Utility.Mathematics;
 
 namespace ElectronicObserver.Window.Tools.EquipmentUpgradePlanner.Helpers;
 
@@ -28,7 +29,7 @@ public class EquipmentUpgradeHelpersDayViewModel
 
 		BackgroundColor = helperDay switch
 		{
-			true => day == TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.Today, "Tokyo Standard Time").DayOfWeek ? Color.FromArgb(255, 30, 142, 255) : Color.FromArgb(153, 65, 65, 247),
+			true => day == DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek ? Color.FromArgb(255, 30, 142, 255) : Color.FromArgb(153, 65, 65, 247),
 			_ => Color.FromArgb(0, 0, 0, 0),
 		};
 	}

--- a/ElectronicObserver/Window/Wpf/EquipmentUpgradePlanViewer/EquipmentUpgradePlanViewerView.xaml
+++ b/ElectronicObserver/Window/Wpf/EquipmentUpgradePlanViewer/EquipmentUpgradePlanViewerView.xaml
@@ -43,11 +43,10 @@
 		</Grid.RowDefinitions>
 
 		<StackPanel Grid.Row="0" Orientation="Horizontal">
-			<CheckBox
-				Margin="10 0 0 0"
-				Content="{Binding Translation.All}"
-				IsChecked="{Binding Filters.SelectAllDay}"
-				/>
+
+			<CheckBox Content="{Binding Filters.TodayDisplay}" IsChecked="{Binding Filters.SelectToday}" />
+
+			<CheckBox Content="{Binding Translation.All}" IsChecked="{Binding Filters.SelectAllDay}" />
 
 			<ItemsControl ItemsSource="{Binding Filters.Days}">
 


### PR DESCRIPTION
- Add a way to filter upgrades on current day in upgrade plan viewer
- Add a way to filter upgrades on current day in upgrade planner
- Im not sure about current implementation
- Also days translation gets updated on config change