### PR TITLE
Taiha warning rework

### DIFF
--- a/ElectronicObserver/Window/Wpf/Fleet/FleetView.xaml
+++ b/ElectronicObserver/Window/Wpf/Fleet/FleetView.xaml
@@ -18,72 +18,22 @@
 	>
 	<UserControl.Resources>
 		<ResourceDictionary>
-			<!--
-			
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="../Resources.xaml" />
-			</ResourceDictionary.MergedDictionaries>
-			
 			<Storyboard
-				x:Key="Taiha"
+				x:Key="TaihaStoryboard"
+				RepeatBehavior="Forever"
 				Storyboard.TargetProperty="Background.(SolidColorBrush.Color)"
-				Duration="0:0:2"
-				RepeatBehavior="Forever"
-			>
-				<ColorAnimationUsingKeyFrames>
-					<DiscreteColorKeyFrame KeyTime="0:0:0" Value="Transparent"/>
-				</ColorAnimationUsingKeyFrames>
-				<ColorAnimationUsingKeyFrames>
-					<DiscreteColorKeyFrame KeyTime="0:0:1" Value="Red"/>
-				</ColorAnimationUsingKeyFrames>
-				<ColorAnimationUsingKeyFrames>
-					<DiscreteColorKeyFrame KeyTime="0:0:2" Value="Transparent"/>
-				</ColorAnimationUsingKeyFrames>
-			</Storyboard>
-			
-			storyboards get frozen for optimization purposes
-			which is why you can't use binding in them, but need hardcoded values instead
-			
-			<Storyboard
-				x:Key="EmptyResources"
-				RepeatBehavior="Forever"
-				Storyboard.TargetProperty="Background.Color"
 				Duration="0:0:2"
 				>
 				<ColorAnimationUsingKeyFrames>
-					<DiscreteColorKeyFrame KeyTime="0:0:0" Value="{Binding ResourceBackgroundBrush}" />
+					<DiscreteColorKeyFrame KeyTime="0:0:0" Value="Transparent" />
 				</ColorAnimationUsingKeyFrames>
 				<ColorAnimationUsingKeyFrames>
-					<DiscreteColorKeyFrame KeyTime="0:0:1" Value="Maroon" />
+					<DiscreteColorKeyFrame KeyTime="0:0:1" Value="Red" />
 				</ColorAnimationUsingKeyFrames>
 				<ColorAnimationUsingKeyFrames>
-					<DiscreteColorKeyFrame KeyTime="0:0:2" Value="{Binding ResourceBackgroundBrush}" />
+					<DiscreteColorKeyFrame KeyTime="0:0:2" Value="Transparent" />
 				</ColorAnimationUsingKeyFrames>
 			</Storyboard>
-
-			<ProgressBar Background="Transparent">
-				<ProgressBar.Style>
-					<Style BasedOn="{StaticResource DefaultProgressBarStyle}" TargetType="ProgressBar">
-						<Style.Triggers>
-							<DataTrigger Binding="{Binding ShouldNotifyEmptyFuel}" Value="True">
-								<DataTrigger.EnterActions>
-									<BeginStoryboard Name="StartEmptyResourcesStoryboard" Storyboard="{StaticResource EmptyResources}" />
-								</DataTrigger.EnterActions>
-								<DataTrigger.ExitActions>
-									<SeekStoryboard
-										BeginStoryboardName="StartEmptyResourcesStoryboard"
-										Origin="BeginTime"
-										Offset="0:0:0"
-										/>
-									<StopStoryboard BeginStoryboardName="StartEmptyResourcesStoryboard" />
-								</DataTrigger.ExitActions>
-							</DataTrigger>
-						</Style.Triggers>
-					</Style>
-				</ProgressBar.Style>
-			</ProgressBar>
-			
-			-->
 
 			<Style TargetType="Border">
 				<Setter Property="Background" Value="Transparent" />
@@ -272,9 +222,28 @@
 						<StackPanel Orientation="Vertical" />
 					</ItemsPanelTemplate>
 				</ItemsControl.ItemsPanel>
+
 				<ItemsControl.ItemTemplate>
 					<DataTemplate DataType="viewModels:FleetItemViewModel">
 						<Border Visibility="{Binding Visibility}">
+							<Border.Style>
+								<Style TargetType="Border">
+									<Setter Property="Background" Value="Transparent" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding CanSink}" Value="True">
+											<DataTrigger.EnterActions>
+												<BeginStoryboard x:Name="BeginTaihaStoryboard" Storyboard="{StaticResource TaihaStoryboard}" />
+											</DataTrigger.EnterActions>
+										</DataTrigger>
+										<DataTrigger Binding="{Binding CanSink}" Value="False">
+											<DataTrigger.EnterActions>
+												<StopStoryboard BeginStoryboardName="BeginTaihaStoryboard" />
+											</DataTrigger.EnterActions>
+										</DataTrigger>
+									</Style.Triggers>
+								</Style>
+							</Border.Style>
+
 							<Border.Resources>
 								<Style TargetType="Border">
 									<Setter Property="Margin" Value="2 0" />

--- a/ElectronicObserver/Window/Wpf/Fleet/ViewModels/FleetItemViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Fleet/ViewModels/FleetItemViewModel.cs
@@ -41,6 +41,7 @@ public class FleetItemViewModel : ObservableObject
 	public Dictionary<SpecialAttack, List<SpecialAttackHit>> SpecialAttackHitList { get; set; } = new();
 
 	public ShipData? Ship { get; private set; }
+	public bool CanSink { get; private set; }
 
 	public string? ShipName => Ship switch
 	{
@@ -111,8 +112,12 @@ public class FleetItemViewModel : ObservableObject
 
 		KCDatabase db = KCDatabase.Instance;
 
+		IFleetData fleet = db.Fleet[Parent.FleetId];
 		bool isEscaped = db.Fleet[Parent.FleetId].EscapedShipList.Contains(shipMasterID);
-		var equipments = Ship.AllSlotInstance.Where(eq => eq != null);
+		IEnumerable<IEquipmentData> equipments = Ship.AllSlotInstance
+			.Where(eq => eq != null);
+
+		CanSink = Ship.CanSink(fleet);
 
 		UpdateShipName(equipments);
 
@@ -132,7 +137,7 @@ public class FleetItemViewModel : ObservableObject
 	private void UpdateCondition()
 	{
 		if (Ship is null) return;
-			
+
 		Condition.Text = Ship.Condition.ToString();
 		Condition.Tag = Ship.Condition;
 		Condition.SetDesign(Ship.Condition);
@@ -247,7 +252,7 @@ public class FleetItemViewModel : ObservableObject
 			.DistinctBy(p => p.TargetLevel)
 			.ToList();
 
-		foreach(ShipTrainingPlanViewModel plan in plans.Where(p => p.TargetLevel < 99))
+		foreach (ShipTrainingPlanViewModel plan in plans.Where(p => p.TargetLevel < 99))
 		{
 			tip.AppendFormat(GeneralRes.ToX + " exp.\r\n", plan.TargetLevel, plan.RemainingExpToTarget.ToString("N0"));
 		}
@@ -317,8 +322,8 @@ public class FleetItemViewModel : ObservableObject
 	private Color GetShipForeColor(Color backColor)
 	{
 		if (Configuration.Config.FormFleet.AppliesSallyAreaColor &&
-		    Parent.ShipTagColors.Count > 0 &&
-		    Ship?.SallyArea > 0)
+			Parent.ShipTagColors.Count > 0 &&
+			Ship?.SallyArea > 0)
 		{
 			return ColorService.GetForegroundColor(backColor);
 		}

--- a/ElectronicObserver/Window/Wpf/Fleet/ViewModels/FleetStateViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Fleet/ViewModels/FleetStateViewModel.cs
@@ -11,6 +11,7 @@ using ElectronicObserver.Utility.Data;
 using ElectronicObserver.Utility.Mathematics;
 using ElectronicObserver.ViewModels.Translations;
 using ElectronicObserver.Window.Control;
+using ElectronicObserverTypes.Extensions;
 
 namespace ElectronicObserver.Window.Wpf.Fleet.ViewModels;
 
@@ -130,7 +131,7 @@ public class FleetStateViewModel : ObservableObject
 			}
 
 			//大破艦あり
-			if (!fleet.IsInSortie && fleet.MembersWithoutEscaped.Any(s => s != null && s.HPRate <= 0.25 && s.RepairingDockID == -1))
+			if (!fleet.IsInSortie && fleet.MembersWithoutEscaped.Any(s => s != null && s.CanSink(fleet)))
 			{
 				var state = GetStateLabel(index);
 

--- a/ElectronicObserver/Window/Wpf/Fleet/ViewModels/FleetStateViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Fleet/ViewModels/FleetStateViewModel.cs
@@ -131,7 +131,7 @@ public class FleetStateViewModel : ObservableObject
 			}
 
 			//大破艦あり
-			if (!fleet.IsInSortie && fleet.MembersWithoutEscaped.Any(s => s != null && s.CanSink(fleet)))
+			if (!fleet.IsInSortie && fleet.MembersWithoutEscaped!.Any(s => s != null && s.CanSink(fleet)))
 			{
 				var state = GetStateLabel(index);
 

--- a/ElectronicObserverCoreTests/CanSinkTests.cs
+++ b/ElectronicObserverCoreTests/CanSinkTests.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using ElectronicObserverTypes;
+using ElectronicObserverTypes.Extensions;
+using ElectronicObserverTypes.Mocks;
+using Xunit;
+
+namespace ElectronicObserverCoreTests;
+
+[Collection(DatabaseCollection.Name)]
+public class CanSinkTests
+{
+	private DatabaseFixture Db { get; }
+
+	public CanSinkTests(DatabaseFixture db)
+	{
+		Db = db;
+	}
+
+	[Fact(DisplayName = "Basic case")]
+	public void CanSinkTest1()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai]);
+		ShipDataMock asakaze = new(Db.MasterShips[ShipId.AsakazeKai])
+		{
+			HPCurrent = 1,
+		};
+
+		FleetDataMock fleet = new()
+		{
+			MembersInstance = new ReadOnlyCollection<IShipData?>(new List<IShipData?>
+			{
+				kamikaze,
+				asakaze,
+			}),
+		};
+
+		Assert.False(kamikaze.CanSink(fleet));
+		Assert.True(asakaze.CanSink(fleet));
+	}
+
+	[Fact(DisplayName = "Taiha flagship")]
+	public void CanSinkTest2()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai]);
+		ShipDataMock asakaze = new(Db.MasterShips[ShipId.AsakazeKai])
+		{
+			HPCurrent = 1,
+		};
+
+		FleetDataMock fleet = new()
+		{
+			MembersInstance = new ReadOnlyCollection<IShipData?>(new List<IShipData?>
+			{
+				asakaze,
+				kamikaze,
+			}),
+		};
+
+		Assert.False(kamikaze.CanSink(fleet));
+		Assert.False(asakaze.CanSink(fleet));
+	}
+
+	[Fact(DisplayName = "With damecon")]
+	public void CanSinkTest3()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai]);
+		ShipDataMock asakaze = new(Db.MasterShips[ShipId.AsakazeKai])
+		{
+			HPCurrent = 1,
+			SlotInstance = new List<IEquipmentData?>
+			{
+				new EquipmentDataMock(Db.MasterEquipment[EquipmentId.DamageControl_EmergencyRepairPersonnel]),
+			},
+		};
+
+		FleetDataMock fleet = new()
+		{
+			MembersInstance = new ReadOnlyCollection<IShipData?>(new List<IShipData?>
+			{
+				kamikaze,
+				asakaze,
+			}),
+		};
+
+		Assert.False(kamikaze.CanSink(fleet));
+		Assert.False(asakaze.CanSink(fleet));
+	}
+
+	[Fact(DisplayName = "Escaped")]
+	public void CanSinkTest4()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai]);
+		ShipDataMock asakaze = new(Db.MasterShips[ShipId.AsakazeKai])
+		{
+			HPCurrent = 1,
+		};
+
+		FleetDataMock fleet = new()
+		{
+			MembersInstance = new ReadOnlyCollection<IShipData?>(new List<IShipData?>
+			{
+				kamikaze,
+				asakaze,
+			}),
+		};
+
+		fleet.Escape(fleet.MembersInstance.IndexOf(asakaze) + 1);
+
+		Assert.False(kamikaze.CanSink(fleet));
+		Assert.False(asakaze.CanSink(fleet));
+	}
+
+	[Fact(DisplayName = "Docked")]
+	public void CanSinkTest5()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai]);
+		ShipDataMock asakaze = new(Db.MasterShips[ShipId.AsakazeKai])
+		{
+			HPCurrent = 1,
+			RepairingDockID = 0,
+		};
+
+		FleetDataMock fleet = new()
+		{
+			MembersInstance = new ReadOnlyCollection<IShipData?>(new List<IShipData?>
+			{
+				kamikaze,
+				asakaze,
+			}),
+		};
+
+		Assert.False(kamikaze.CanSink(fleet));
+		Assert.False(asakaze.CanSink(fleet));
+	}
+}

--- a/ElectronicObserverTypes/Extensions/ShipDataExtensions.cs
+++ b/ElectronicObserverTypes/Extensions/ShipDataExtensions.cs
@@ -562,4 +562,17 @@ public static class ShipDataExtensions
 			EquipmentId.Autogyro_S51J or
 			EquipmentId.Autogyro_S51JKai);
 	}
+
+	public static bool CanSink(this IShipData ship, IFleetData fleet)
+	{
+		if (ship.HPRate > 0.25) return false;
+		if (fleet.MembersInstance.FirstOrDefault() == ship) return false;
+		if (ship.HasDamecon()) return false;
+		if (ship.RepairingDockID > -1) return false;
+
+		return fleet.MembersWithoutEscaped!.Contains(ship);
+	}
+
+	private static bool HasDamecon(this IShipData ship) => ship.AllSlotInstance
+		.Any(e => e?.MasterEquipment.CategoryType is EquipmentTypes.DamageControl);
 }

--- a/ElectronicObserverTypes/Mocks/ShipDataMock.cs
+++ b/ElectronicObserverTypes/Mocks/ShipDataMock.cs
@@ -121,7 +121,7 @@ public class ShipDataMock : IShipData
 	public int SortID { get; set; }
 	public int SallyArea { get; set; }
 	public IShipDataMaster MasterShip { get; set; }
-	public int RepairingDockID { get; set; }
+	public int RepairingDockID { get; set; } = -1;
 	public int Fleet { get; set; }
 	public string FleetWithIndex { get; set; }
 	public bool IsMarried => Level > 99;


### PR DESCRIPTION
Rework taiha warning in fleet view, so the red blinking only happens when a ship can actually sink.

- flagships can never sink
- ships with damecon can't sink

Additionally, the ship who is in danger of sinking will also get red blinking, instead of just the fleet status.

An example:
![image](https://github.com/ElectronicObserverEN/ElectronicObserver/assets/40002167/2ec9ba29-3891-46d8-8f77-b4394cf9fbb0)
![image](https://github.com/ElectronicObserverEN/ElectronicObserver/assets/40002167/a1e1f284-29a0-41cb-a36c-4bd366ee3c40)
