### PR TITLE
Add next parameter level to exp tooltip

### DIFF
--- a/ElectronicObserver/Resource/Record/ShipParameterRecord.cs
+++ b/ElectronicObserver/Resource/Record/ShipParameterRecord.cs
@@ -147,6 +147,17 @@ public class ShipParameterRecord : RecordBase
 			return CalculateParameter(level, Minimum, Maximum);
 		}
 
+		public int? GetNextLevel(int level, int? current = null)
+		{
+			if (!IsAvailable) return null;
+			if (!IsDetermined) return null;
+			if (Maximum <= Minimum) return null;
+
+			int target = (current ?? GetParameter(level)) + 1;
+
+			return (int)Math.Ceiling(((target - Minimum) * 99.0) / (Maximum - Minimum));
+		}
+
 		private int CalculateParameter(int level, int min, int max)
 		{
 			return min + (int)((max - min) * level / 99.0);

--- a/ElectronicObserver/Window/GeneralRes.en.resx
+++ b/ElectronicObserver/Window/GeneralRes.en.resx
@@ -836,4 +836,13 @@ Please click here to restart.</value>
   <data name="Edit" xml:space="preserve">
     <value>Edit</value>
   </data>
+  <data name="NextAccuracy" xml:space="preserve">
+    <value>Next accuracy</value>
+  </data>
+  <data name="NextEvasion" xml:space="preserve">
+    <value>Next evasion</value>
+  </data>
+  <data name="NextAsw" xml:space="preserve">
+    <value>Next ASW</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/GeneralRes.resx
+++ b/ElectronicObserver/Window/GeneralRes.resx
@@ -835,4 +835,13 @@
   <data name="Edit" xml:space="preserve">
     <value>編集</value>
   </data>
+  <data name="NextAccuracy" xml:space="preserve">
+    <value>次の命中項</value>
+  </data>
+  <data name="NextEvasion" xml:space="preserve">
+    <value>次の回避</value>
+  </data>
+  <data name="NextAsw" xml:space="preserve">
+    <value>次の対潜</value>
+  </data>
 </root>

--- a/ElectronicObserverCoreTests/AccuracyTests.cs
+++ b/ElectronicObserverCoreTests/AccuracyTests.cs
@@ -2,6 +2,7 @@
 using ElectronicObserver.Utility.Data;
 using ElectronicObserverTypes;
 using ElectronicObserverTypes.Attacks;
+using ElectronicObserverTypes.Extensions;
 using ElectronicObserverTypes.Mocks;
 using Xunit;
 
@@ -46,5 +47,17 @@ public class AccuracyTests
 		double expected = 160;
 
 		Assert.Equal(expected, bismarck.GetDayAttackAccuracy(DayAttackKind.NormalAttack, fleet));
+	}
+
+	[Fact]
+	public void AccuracyTest2()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai])
+		{
+			Level = 180,
+			LuckBase = 99,
+		};
+
+		Assert.Equal(184, kamikaze.NextAccuracyLevel());
 	}
 }

--- a/ElectronicObserverCoreTests/ParameterTests.cs
+++ b/ElectronicObserverCoreTests/ParameterTests.cs
@@ -1,0 +1,40 @@
+﻿using ElectronicObserverTypes.Mocks;
+using ElectronicObserverTypes;
+using Xunit;
+
+namespace ElectronicObserverCoreTests;
+
+[Collection(DatabaseCollection.Name)]
+public class ParameterTests
+{
+	private DatabaseFixture Db { get; }
+
+	public ParameterTests(DatabaseFixture db)
+	{
+		Db = db;
+	}
+
+	[Fact]
+	public void ParameterTest1()
+	{
+		ShipDataMock kamikaze = new(Db.MasterShips[ShipId.KamikazeKai])
+		{
+			Level = 180,
+		};
+		
+		Assert.Equal(182, kamikaze.MasterShip.ASW.GetNextLevel(kamikaze.Level));
+		Assert.Equal(183, kamikaze.MasterShip.Evasion.GetNextLevel(kamikaze.Level));
+	}
+
+	[Fact(DisplayName = "Ship without ASW")]
+	public void ParameterTest2()
+	{
+		ShipDataMock bismarck = new(Db.MasterShips[ShipId.BismarckDrei])
+		{
+			Level = 180,
+		};
+
+		Assert.Null(bismarck.MasterShip.ASW.GetNextLevel(bismarck.Level));
+		Assert.Equal(181, bismarck.MasterShip.Evasion.GetNextLevel(bismarck.Level));
+	}
+}

--- a/ElectronicObserverTypes/Extensions/ShipDataExtensions.cs
+++ b/ElectronicObserverTypes/Extensions/ShipDataExtensions.cs
@@ -27,6 +27,14 @@ public static class ShipDataExtensions
 	public static double Accuracy(this IShipData ship) =>
 		2 * Math.Sqrt(ship.Level) + 1.5 * Math.Sqrt(ship.LuckTotal);
 
+	public static int NextAccuracyLevel(this IShipData ship, int? currentAccuracy = null)
+	{
+		int targetAccuracy = (currentAccuracy ?? (int)ship.Accuracy()) + 1;
+		double luckPart = 1.5 * Math.Sqrt(ship.LuckTotal);
+
+		return (int)Math.Ceiling(Math.Pow((targetAccuracy - luckPart) / 2, 2));
+	}
+
 	public static double ShellingEvasion(this IShipData ship) =>
 		new ShellingEvasion(ship).PostcapValue;
 

--- a/ElectronicObserverTypes/IParameter.cs
+++ b/ElectronicObserverTypes/IParameter.cs
@@ -60,4 +60,12 @@ public interface IParameter
 	public int GetEstParameterMax(int level);
 
 	public int GetParameter(int level);
+
+	/// <summary>
+	/// Returns the level when the parameter will increase, null if increase is impossible.
+	/// </summary>
+	/// <param name="level">Current ship level.</param>
+	/// <param name="current">Current parameter value.</param>
+	/// <returns>Level or null if the parameter will never increase.</returns>
+	public int? GetNextLevel(int level, int? current = null);
 }

--- a/ElectronicObserverTypes/Mocks/ParameterMock.cs
+++ b/ElectronicObserverTypes/Mocks/ParameterMock.cs
@@ -1,4 +1,6 @@
-﻿namespace ElectronicObserverTypes.Mocks;
+﻿using System;
+
+namespace ElectronicObserverTypes.Mocks;
 
 public class ParameterMock : IParameter
 {
@@ -13,7 +15,7 @@ public class ParameterMock : IParameter
 
 	public ParameterMock()
 	{
-		
+
 	}
 
 	public ParameterMock(int minimum, int maximum)
@@ -40,6 +42,17 @@ public class ParameterMock : IParameter
 	}
 
 	public int GetParameter(int level) => CalculateParameter(level, Minimum, Maximum);
+
+	public int? GetNextLevel(int level, int? current = null)
+	{
+		if (!IsAvailable) return null;
+		if (!IsDetermined) return null;
+		if (Maximum <= Minimum) return null;
+
+		int target = (current ?? GetParameter(level)) + 1;
+
+		return (int)Math.Ceiling(((target - Minimum) * 99.0) / (Maximum - Minimum));
+	}
 
 	private static int CalculateParameter(int level, int min, int max) =>
 		min + (int)((max - min) * level / 99.0);


### PR DESCRIPTION
The parameters displayed are accuracy, evasion and ASW. Ships whose ASW can't be increased by leveling won't have it displayed in the tooltip.

I'm not too sure about the display in the parentheses, maybe it should be `Next accuracy(26→27) (83): ...` instead?

![image](https://github.com/ElectronicObserverEN/ElectronicObserver/assets/40002167/9fadd5d6-e11b-4a1c-9c4a-0fb0b58b48cc)

I also adjusted the other leveling items logic a bit. They all just get pushed in a list, and then get picked out by distinct levels and ordered accordingly.