### PR TITLE
Sortie record Special Attack fix

### DIFF
--- a/ElectronicObserver/Data/Battle/Phase/PhaseNightBattle.cs
+++ b/ElectronicObserver/Data/Battle/Phase/PhaseNightBattle.cs
@@ -77,68 +77,48 @@ public class PhaseNightBattle : PhaseBase
 
 	public override void EmulateBattle(int[] hps, int[] damages)
 	{
-
 		if (!IsAvailable) return;
-
 
 		foreach (var atk in Attacks)
 		{
-			switch ((NightAttackKind)atk.AttackType)
+			if (atk.AttackTypeTyped.IsSpecialAttack())
 			{
-				case NightAttackKind.SpecialNelson:
-					for (int i = 0; i < atk.Defenders.Count; i++)
+				List<int> attackers = atk.AttackTypeTyped switch
+				{
+					NightAttackKind.CutinZuiun => Enumerable.Repeat(atk.Attacker.Index, 2).ToList(),
+					_ => atk.AttackTypeTyped.SpecialAttackIndexes(),
+				};
+
+				int fleetCount = KCDatabase.Instance.Fleet.Fleets.Values
+					.Count(f => f.IsInSortie);
+
+				for (int i = 0; i < atk.Defenders.Count; i++)
+				{
+					List<FleetData> fleets = KCDatabase.Instance.Fleet.Fleets.Values
+						.Where(f => f.IsInSortie)
+						.ToList();
+
+					int attackerIndex = attackers[i];
+
+					BattleIndex comboatk = fleets.Count switch
 					{
-						var comboatk = new BattleIndex(atk.Attacker.Side, i * 2);       // #1, #3, #5
-						BattleDetails.Add(new BattleNightDetail(Battle, comboatk, atk.Defenders[i].Defender, new[] { atk.Defenders[i].RawDamage }, new[] { atk.Defenders[i].CriticalFlag }, atk.AttackType, atk.EquipmentIDs, atk.NightAirAttackFlag, hps[atk.Defenders[i].Defender]));
-						AddDamage(hps, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
-						damages[comboatk] += atk.Defenders[i].Damage;
-					}
-					break;
+						2 => new(attackerIndex + 6, true, true),
+						_ => new BattleIndex(atk.Attacker.Side, attackerIndex)
+					};
 
-				case NightAttackKind.SpecialNagato:
-				case NightAttackKind.SpecialMutsu:
-				case NightAttackKind.SpecialYamato2Ships:
-					for (int i = 0; i < atk.Defenders.Count; i++)
-					{
-						var comboatk = new BattleIndex(atk.Attacker.Side, i / 2);       // #1, #1, #2
-						BattleDetails.Add(new BattleNightDetail(Battle, comboatk, atk.Defenders[i].Defender, new[] { atk.Defenders[i].RawDamage }, new[] { atk.Defenders[i].CriticalFlag }, atk.AttackType, atk.EquipmentIDs, atk.NightAirAttackFlag, hps[atk.Defenders[i].Defender]));
-						AddDamage(hps, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
-						damages[comboatk] += atk.Defenders[i].Damage;
-					}
-					break;
-
-				case NightAttackKind.SpecialColorado:
-				case NightAttackKind.SpecialKongou:
-				case NightAttackKind.SpecialYamato3Ships:
-					for (int i = 0; i < atk.Defenders.Count; i++)
-					{
-						List<FleetData> fleets = KCDatabase.Instance.Fleet.Fleets.Values
-							.Where(f => f.IsInSortie)
-							.ToList();
-
-						BattleIndex comboatk = fleets.Count switch
-						{
-							// hack: Kongou night special attack index is messed up for combined fleet vs combined fleet
-							// todo: need to check what happens in case only 1 of the fleets is combined
-							// note: when testing via api replay you need a combined fleet in-game, else fleet data (count) won't be correct
-							2 when i < 6 => new(i + 6, true, true),
-							_ => new BattleIndex(atk.Attacker.Side, i)
-						};
-
-						BattleDetails.Add(new BattleNightDetail(Battle, comboatk, atk.Defenders[i].Defender, new[] { atk.Defenders[i].RawDamage }, new[] { atk.Defenders[i].CriticalFlag }, atk.AttackType, atk.EquipmentIDs, atk.NightAirAttackFlag, hps[atk.Defenders[i].Defender]));
-						AddDamage(hps, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
-						damages[comboatk] += atk.Defenders[i].Damage;
-					}
-					break;
-
-				default:
-					foreach (var defs in atk.Defenders.GroupBy(d => d.Defender))
-					{
-						BattleDetails.Add(new BattleNightDetail(Battle, atk.Attacker, defs.Key, defs.Select(d => d.RawDamage).ToArray(), defs.Select(d => d.CriticalFlag).ToArray(), atk.AttackType, atk.EquipmentIDs, atk.NightAirAttackFlag, hps[defs.Key]));
-						AddDamage(hps, defs.Key, defs.Sum(d => d.Damage));
-					}
-					damages[atk.Attacker] += atk.Defenders.Sum(d => d.Damage);
-					break;
+					BattleDetails.Add(new BattleNightDetail(Battle, comboatk, atk.Defenders[i].Defender, new[] { atk.Defenders[i].RawDamage }, new[] { atk.Defenders[i].CriticalFlag }, atk.AttackType, atk.EquipmentIDs, atk.NightAirAttackFlag, hps[atk.Defenders[i].Defender]));
+					AddDamage(hps, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
+					damages[comboatk] += atk.Defenders[i].Damage;
+				}
+			}
+			else 
+			{
+				foreach (var defs in atk.Defenders.GroupBy(d => d.Defender))
+				{
+					BattleDetails.Add(new BattleNightDetail(Battle, atk.Attacker, defs.Key, defs.Select(d => d.RawDamage).ToArray(), defs.Select(d => d.CriticalFlag).ToArray(), atk.AttackType, atk.EquipmentIDs, atk.NightAirAttackFlag, hps[defs.Key]));
+					AddDamage(hps, defs.Key, defs.Sum(d => d.Damage));
+				}
+				damages[atk.Attacker] += atk.Defenders.Sum(d => d.Damage);
 			}
 		}
 
@@ -149,9 +129,15 @@ public class PhaseNightBattle : PhaseBase
 	public class PhaseNightBattleAttack
 	{
 		public BattleIndex Attacker;
+
 		public int AttackType;
+
+		public NightAttackKind AttackTypeTyped => (NightAttackKind)AttackType;
+
 		public bool NightAirAttackFlag;
+
 		public List<PhaseNightBattleDefender> Defenders;
+
 		public int[] EquipmentIDs;
 
 		public PhaseNightBattleAttack()

--- a/ElectronicObserver/Data/Battle/Phase/PhaseNightBattle.cs
+++ b/ElectronicObserver/Data/Battle/Phase/PhaseNightBattle.cs
@@ -74,7 +74,6 @@ public class PhaseNightBattle : PhaseBase
 
 	private string ShellingDataName => PhaseID == 0 ? "api_hougeki" : ("api_n_hougeki" + PhaseID);
 
-
 	public override void EmulateBattle(int[] hps, int[] damages)
 	{
 		if (!IsAvailable) return;
@@ -94,13 +93,9 @@ public class PhaseNightBattle : PhaseBase
 
 				for (int i = 0; i < atk.Defenders.Count; i++)
 				{
-					List<FleetData> fleets = KCDatabase.Instance.Fleet.Fleets.Values
-						.Where(f => f.IsInSortie)
-						.ToList();
-
 					int attackerIndex = attackers[i];
 
-					BattleIndex comboatk = fleets.Count switch
+					BattleIndex comboatk = fleetCount switch
 					{
 						2 => new(attackerIndex + 6, true, true),
 						_ => new BattleIndex(atk.Attacker.Side, attackerIndex)

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/Sortie/Battle/Phase/PhaseShelling.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/Sortie/Battle/Phase/PhaseShelling.cs
@@ -88,64 +88,29 @@ public class PhaseShelling : PhaseBase
 
 		foreach (PhaseShellingAttack atk in Attacks)
 		{
-			switch (atk.AttackType)
+			if (atk.AttackType.IsSpecialAttack())
 			{
-				case DayAttackKind.SpecialNelson:
-					for (int i = 0; i < atk.Defenders.Count; i++)
+				List<int> attackers = atk.AttackType.SpecialAttackIndexes();
+
+				for (int i = 0; i < atk.Defenders.Count; i++)
+				{
+					PhaseShellingAttack comboAttack = atk with
 					{
-						PhaseShellingAttack comboAttack = atk with
-						{
-							// #1, #3, #5
-							Attacker = new(i * 2, FleetFlag.Player),
-							Defenders = new() { atk.Defenders[i] },
-						};
+						Attacker = new(attackers[i], FleetFlag.Player),
+						Defenders = new() { atk.Defenders[i] },
+					};
 
-						AttackDisplays.Add(new PhaseShellingAttackViewModel(FleetsAfterPhase, comboAttack));
-						AddDamage(FleetsAfterPhase, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
-					}
-					break;
-
-				case DayAttackKind.SpecialNagato:
-				case DayAttackKind.SpecialMutsu:
-				case DayAttackKind.SpecialYamato2Ships:
-					for (int i = 0; i < atk.Defenders.Count; i++)
-					{
-						PhaseShellingAttack comboAttack = atk with
-						{
-							// #1, #1, #2
-							Attacker = new(i / 2, FleetFlag.Player),
-							Defenders = new() { atk.Defenders[i] },
-						};
-
-						AttackDisplays.Add(new PhaseShellingAttackViewModel(FleetsAfterPhase, comboAttack));
-						AddDamage(FleetsAfterPhase, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
-					}
-					break;
-
-				case DayAttackKind.SpecialColorado:
-				case DayAttackKind.SpecialKongo:
-				case DayAttackKind.SpecialYamato3Ships:
-					for (int i = 0; i < atk.Defenders.Count; i++)
-					{
-						PhaseShellingAttack comboAttack = atk with
-						{
-							// #1, #2, #3
-							Attacker = new(i, FleetFlag.Player),
-							Defenders = new() { atk.Defenders[i] },
-						};
-
-						AttackDisplays.Add(new PhaseShellingAttackViewModel(FleetsAfterPhase, comboAttack));
-						AddDamage(FleetsAfterPhase, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
-					}
-					break;
-
-				default:
-					foreach (IGrouping<BattleIndex, PhaseShellingDefender> defs in atk.Defenders.GroupBy(d => d.Defender))
-					{
-						AttackDisplays.Add(new PhaseShellingAttackViewModel(FleetsAfterPhase, atk));
-						AddDamage(FleetsAfterPhase, defs.Key, defs.Sum(d => d.Damage));
-					}
-					break;
+					AttackDisplays.Add(new PhaseShellingAttackViewModel(FleetsAfterPhase, comboAttack));
+					AddDamage(FleetsAfterPhase, atk.Defenders[i].Defender, atk.Defenders[i].Damage);
+				}
+			}
+			else
+			{
+				foreach (IGrouping<BattleIndex, PhaseShellingDefender> defs in atk.Defenders.GroupBy(d => d.Defender))
+				{
+					AttackDisplays.Add(new PhaseShellingAttackViewModel(FleetsAfterPhase, atk));
+					AddDamage(FleetsAfterPhase, defs.Key, defs.Sum(d => d.Damage));
+				}
 			}
 		}
 

--- a/ElectronicObserverTypes/Attacks/Extensions.cs
+++ b/ElectronicObserverTypes/Attacks/Extensions.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ElectronicObserverTypes.Attacks;
+
+public static class Extensions
+{
+	public static bool IsSpecialAttack(this DayAttackKind dayAttack) => dayAttack is
+		DayAttackKind.SpecialNelson or
+		DayAttackKind.SpecialNagato or
+		DayAttackKind.SpecialMutsu or
+		DayAttackKind.SpecialColorado or
+		DayAttackKind.SpecialKongo or
+		DayAttackKind.SpecialSubmarineTender23 or
+		DayAttackKind.SpecialSubmarineTender34 or
+		DayAttackKind.SpecialSubmarineTender24 or
+		DayAttackKind.SpecialYamato2Ships or
+		DayAttackKind.SpecialYamato3Ships;
+
+	public static bool IsSpecialAttack(this NightAttackKind nightAttack) => nightAttack is
+		NightAttackKind.CutinZuiun or
+		NightAttackKind.SpecialNelson or
+		NightAttackKind.SpecialNagato or
+		NightAttackKind.SpecialMutsu or
+		NightAttackKind.SpecialColorado or
+		NightAttackKind.SpecialKongou or
+		NightAttackKind.SpecialSubmarineTender23 or
+		NightAttackKind.SpecialSubmarineTender34 or
+		NightAttackKind.SpecialSubmarineTender24 or
+		NightAttackKind.SpecialYamato2Ships or
+		NightAttackKind.SpecialYamato3Ships;
+
+	public static List<int> SpecialAttackParticipationIndexes(this DayAttackKind? dayAttack)
+		=> dayAttack switch
+		{
+			{ } atk => atk switch
+			{
+				DayAttackKind.SpecialSubmarineTender23 or
+				DayAttackKind.SpecialSubmarineTender34 or
+				DayAttackKind.SpecialSubmarineTender24 => SpecialAttackIndexes(atk)
+					.Append(0)
+					.Distinct()
+					.ToList(),
+
+				_ => SpecialAttackIndexes(atk)
+					.Distinct()
+					.ToList()
+			},
+
+			_ => [],
+		};
+
+	public static List<int> SpecialAttackParticipationIndexes(this NightAttackKind? nightAttack)
+		=> nightAttack switch
+		{
+			{ } atk => atk switch
+			{
+				NightAttackKind.SpecialSubmarineTender23 or
+				NightAttackKind.SpecialSubmarineTender34 or
+				NightAttackKind.SpecialSubmarineTender24 => SpecialAttackIndexes(atk)
+					.Append(0)
+					.Distinct()
+					.ToList(),
+
+				_ => SpecialAttackIndexes(atk)
+					.Distinct()
+					.ToList()
+			},
+
+			_ => [],
+		};
+
+	public static List<int> SpecialAttackIndexes(this DayAttackKind dayAttack)
+		=> dayAttack switch
+		{
+			DayAttackKind.SpecialNelson => [0, 2, 4],
+
+			DayAttackKind.SpecialNagato or
+			DayAttackKind.SpecialMutsu or
+			DayAttackKind.SpecialYamato2Ships => [0, 0, 1],
+
+			DayAttackKind.SpecialColorado or
+			DayAttackKind.SpecialYamato3Ships => [0, 1, 2],
+
+			DayAttackKind.SpecialSubmarineTender23 => [1, 2, 1, 2],
+			DayAttackKind.SpecialSubmarineTender34 => [2, 3, 2, 3],
+			DayAttackKind.SpecialSubmarineTender24 => [1, 3, 1, 3],
+
+			_ => [],
+		};
+	
+	public static List<int> SpecialAttackIndexes(this NightAttackKind nightAttack)
+		=> nightAttack switch
+		{
+			NightAttackKind.SpecialNelson => [0, 2, 4],
+
+			NightAttackKind.SpecialNagato or
+			NightAttackKind.SpecialMutsu or
+			NightAttackKind.SpecialYamato2Ships => [0, 0, 1],
+
+			NightAttackKind.SpecialKongou => [0, 1],
+
+			NightAttackKind.SpecialColorado or
+			NightAttackKind.SpecialYamato3Ships => [0, 1, 2],
+
+			NightAttackKind.SpecialSubmarineTender23 => [1, 2, 1, 2],
+			NightAttackKind.SpecialSubmarineTender34 => [2, 3, 2, 3],
+			NightAttackKind.SpecialSubmarineTender24 => [1, 3, 1, 3],
+
+			_ => [],
+		};
+}


### PR DESCRIPTION
- Sub touch isn't displayed properly in sortie record, this PR goal is to fix that issue

![image](https://github.com/ElectronicObserverEN/ElectronicObserver/assets/22751386/bbc464aa-f28e-4ba9-a49b-d32fb8b2bab8)

- I reused code from the sortie cost PR. Code duplication can be reduced thanks to that extension https://github.com/ElectronicObserverEN/ElectronicObserver/blob/SortieCost/ElectronicObserverTypes/Attacks/Extensions.cs
- Need confirmation that sub special attack attackers indexes are Sub 1, Sub 2, Sub 1, Sub 2 / Sub 1, Sub 2, Sub 1 or Sub 1, Sub 2
- Need to test for yasen combined because i removed a whole To-do