### PR TITLE
Csv export performance improvement

### DIFF
--- a/ElectronicObserver/Common/ContentDialogs/ExportFilter/ExportFilterContentDialog.xaml
+++ b/ElectronicObserver/Common/ContentDialogs/ExportFilter/ExportFilterContentDialog.xaml
@@ -21,8 +21,10 @@
 	</ui:ContentDialog.Resources>
 
 	<Grid>
-		<ScrollViewer>
-			<ItemsControl ItemsSource="{Binding Destinations}" />
-		</ScrollViewer>
+		<ListBox
+			ItemsSource="{Binding Destinations}"
+			VirtualizingStackPanel.IsVirtualizing="True"
+			VirtualizingStackPanel.VirtualizationMode="Recycling"
+			/>
 	</Grid>
 </ui:ContentDialog>

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/AirBaseBattleExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/AirBaseBattleExportModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 
-public sealed record AirBaseBattleExportModel
+public sealed record AirBaseBattleExportModel : IExportModel
 {
 	public required CommonDataExportModel CommonData { get; init; }
 	public required int SquadronId { get; init; }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/AirBattleExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/AirBattleExportModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 
-public sealed record AirBattleExportModel
+public sealed record AirBattleExportModel : IExportModel
 {
 	public required CommonDataExportModel CommonData { get; init; }
 	public required AirBattleStageExportModel Stage1 { get; init; }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/CommonDataExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/CommonDataExportModel.cs
@@ -4,7 +4,7 @@ namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 
 public sealed record CommonDataExportModel
 {
-	public required int No { get; init; }
+	public required int No { get; set; }
 	public required DateTime Date { get; init; }
 	public required string World { get; init; }
 	public required string Square { get; init; }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
@@ -161,8 +161,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 
 							dayShellingData.Add(new()
 							{
-								// it's not possible to get the correct record index here
-								CommonData = MakeCommonData(0, battleNode, IsFirstNode(sortieDetail.Nodes, battleNode), sortieDetail, admiralLevel, airBattle, searching),
+								CommonData = MakeCommonData(battleNode, IsFirstNode(sortieDetail.Nodes, battleNode), sortieDetail, admiralLevel, airBattle, searching),
 								BattleType = CsvExportResources.ShellingBattle,
 								ShipName1 = attackerFleet.MembersInstance.Skip(0).FirstOrDefault()?.Name,
 								ShipName2 = attackerFleet.MembersInstance.Skip(1).FirstOrDefault()?.Name,
@@ -284,7 +283,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 
 							nightShellingData.Add(new()
 							{
-								CommonData = MakeCommonData(nightShellingData.Count + 1, battleNode, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, initial, searching),
+								CommonData = MakeCommonData(battleNode, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, initial, searching),
 								BattleType = CsvExportResources.NightBattle,
 								ShipName1 = attackerFleet.MembersInstance.Skip(0).FirstOrDefault()?.Name,
 								ShipName2 = attackerFleet.MembersInstance.Skip(1).FirstOrDefault()?.Name,
@@ -401,7 +400,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 						{
 							torpedoData.Add(new()
 							{
-								CommonData = MakeCommonData(torpedoData.Count + 1, battleNode, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, airBattle, searching),
+								CommonData = MakeCommonData(battleNode, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, airBattle, searching),
 								BattleType = CsvExportResources.TorpedoBattle,
 								PlayerFleetType = GetPlayerFleet(initial.FleetsAfterPhase!, attackDisplay.AttackerIndex, attackDisplay.DefenderIndex),
 								BattlePhase = torpedo switch
@@ -486,7 +485,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 						AirBattleAttackViewModel? attackDisplay = airBattle.AttackDisplays
 							.FirstOrDefault(a => a.DefenderIndex == defenderIndex);
 
-						airBattleData.Add(MakeAirBattleExport(airBattleData.Count + 1, node,
+						airBattleData.Add(MakeAirBattleExport(node,
 							sortieDetail, admiralLevel, airBattle, searching, attackerFleet,
 							attackDisplay, ship, defenderIndex, ship.HPCurrent));
 					}
@@ -565,7 +564,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 
 							airBattleData.Add(new()
 							{
-								CommonData = MakeCommonData(airBattleData.Count + 1, node, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, airAttackUnit, searching),
+								CommonData = MakeCommonData(node, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, airAttackUnit, searching),
 								SquadronId = airAttackUnit.AirBaseId,
 								SquadronAttackIndex = airAttackUnit.WaveIndex + 1,
 								AirBasePlayerContact = airAttackUnit.TouchAircraftFriend,
@@ -760,13 +759,13 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 		return airBattleData;
 	}
 
-	private static AirBattleExportModel MakeAirBattleExport(int no, BattleNode node,
+	private static AirBattleExportModel MakeAirBattleExport(BattleNode node,
 		SortieDetailViewModel sortieDetail, int? admiralLevel, PhaseAirBattle airBattle,
 		PhaseSearching searching, IFleetData attackerFleet, AirBattleAttackViewModel? attackDisplay,
 		IShipData defender, BattleIndex defenderIndex, int defenderHpBeforeAttack)
 		=> new()
 		{
-			CommonData = MakeCommonData(no, node, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, airBattle, searching),
+			CommonData = MakeCommonData(node, IsFirstNode(sortieDetail.Nodes, node), sortieDetail, admiralLevel, airBattle, searching),
 			Stage1 = new()
 			{
 				PlayerAircraftTotal = airBattle.Stage1FCount,
@@ -832,11 +831,13 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 	/// <param name="contactPhase">AirBattle for day battles, NightInitial for night battles.</param>
 	/// <param name="searching">Searching phase.</param>
 	/// <returns>Common data model.</returns>
-	private static CommonDataExportModel MakeCommonData(int no, BattleNode node, bool isFirstNode,
+	private static CommonDataExportModel MakeCommonData(BattleNode node, bool isFirstNode,
 		SortieDetailViewModel sortieDetail, int? admiralLevel, PhaseBase contactPhase,
 		PhaseSearching searching) => new()
 		{
-			No = no,
+			// it's not possible to get the correct record index here
+			// because the data processing is running in parallel
+			No = 0,
 			Date = sortieDetail.StartTime!.Value.ToLocalTime(),
 			World = KCDatabase.Instance.MapInfo[sortieDetail.World * 10 + sortieDetail.Map]?.NameEN ?? "",
 			Square = SquareString(sortieDetail, node),

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
@@ -42,7 +42,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 			.Select(s => s.Model)
 			.WithApiFiles(Db, cancellationToken);
 
-		int? cachedAdmiralLevel = null;
+		int? admiralLevel = null;
 
 		return sortieRecords
 			.AsParallel()
@@ -54,11 +54,10 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 
 				// getting the admiral level is slow as shit
 				// since records are ordered chronologically, the level can't change after 120
-				int? admiralLevel = cachedAdmiralLevel switch
+				if (admiralLevel is not 120)
 				{
-					120 => 120,
-					_ => cachedAdmiralLevel = r.GetAdmiralLevel(Db, cancellationToken).Result,
-				};
+					admiralLevel = r.GetAdmiralLevel(Db, cancellationToken).Result;
+				}
 
 				return dataProcessingFunction(admiralLevel, sortieDetail, exportFilter, exportProgress, cancellationToken);
 			})

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
@@ -824,7 +824,6 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 	/// Makes data that's common between all csv exports.
 	/// This could potentially be split into metadata and battle metadata.
 	/// </summary>
-	/// <param name="no">Export record index.</param>
 	/// <param name="node">Battle node data.</param>
 	/// <param name="isFirstNode">First node flag.</param>
 	/// <param name="sortieDetail">Sortie detail data.</param>

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
@@ -759,6 +759,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 		return airBattleData;
 	}
 
+	[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "I don't see a better way currently")]
 	private static AirBattleExportModel MakeAirBattleExport(BattleNode node,
 		SortieDetailViewModel sortieDetail, int? admiralLevel, PhaseAirBattle airBattle,
 		PhaseSearching searching, IFleetData attackerFleet, AirBattleAttackViewModel? attackDisplay,

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,6 +79,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 		return await ProcessData(ShellingBattle, sorties, exportFilter, exportProgress, cancellationToken);
 	}
 
+	[SuppressMessage("Critical Code Smell", "S3776:Cognitive Complexity of methods should not be too high", Justification = "Splitting this up would cause more problems that it would solve")]
 	private static List<ShellingBattleExportModel> ShellingBattle(
 		int? admiralLevel,
 		SortieDetailViewModel sortieDetail,

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/IExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/IExportModel.cs
@@ -1,0 +1,6 @@
+﻿namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
+
+public interface IExportModel
+{
+	CommonDataExportModel CommonData { get; }
+}

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/NightBattleExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/NightBattleExportModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 
-public sealed record NightBattleExportModel
+public sealed record NightBattleExportModel : IExportModel
 {
 	public required CommonDataExportModel CommonData { get; init; }
 	public required string BattleType { get; init; }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/ShellingBattleExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/ShellingBattleExportModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 
-public sealed record ShellingBattleExportModel
+public sealed record ShellingBattleExportModel : IExportModel
 {
 	public required CommonDataExportModel CommonData { get; init; }
 	public required string BattleType { get; init; }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/TorpedoBattleExportModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/TorpedoBattleExportModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 
-public sealed record TorpedoBattleExportModel
+public sealed record TorpedoBattleExportModel : IExportModel
 {
 	public required CommonDataExportModel CommonData { get; init; }
 	public required string BattleType { get; init; }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/Sortie/Battle/BattleFleets.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/Sortie/Battle/BattleFleets.cs
@@ -20,6 +20,7 @@ public class BattleFleets(
 	public List<IFleetData?>? Fleets { get; } = fleets switch
 	{
 		null => null,
+		{ Count: < 2 } => fleets,
 		_ => [fleet, escortFleet, .. fleets[2..]],
 	};
 


### PR DESCRIPTION
Admiral level fetching is kinda hacky right now. I wonder if it might be better to just grab all the relevant port files from the first sortie to the last one, and then just take the first and last values, and do a binary search if those are different. The slow part is db access, so getting all at once shouldn't be problematic?

- [x] Make sure the initial idea is okay
- [x] Update the other exports

Short explanation:
There are multiple data exports, but they all work exactly the same.

![image](https://github.com/ElectronicObserverEN/ElectronicObserver/assets/40002167/a7540266-bf9b-40e4-ab55-88e58f45cb50)

The first `ShellingBattle` is a wrapper that's meant to make it simpler to use from the outside, so you basically just do `DataExportHelper.ShellingBattle(...)`. I was thinking of removing this wrapper, but I think it's better to have it.

The second `ShellingBattle` is basically just a mapper from `SortieDetailViewModel` to `ShellingBattleExportModel`. The export models then get converted to CSV.

![image](https://github.com/ElectronicObserverEN/ElectronicObserver/assets/40002167/bf0ab0cb-49ed-4d35-bd8f-775fc5af8216)

The `ProcessData` function...
The first parameter is a function with the signature that the second `ShellingBattle` has. This is needed so that those functions only need to do the actual data processing without worrying about loading data, incrementing the progress counters etc.