### PR TITLE
Tooltip text gets cut off with large font size

### DIFF
--- a/ElectronicObserver/Window/Wpf/Fleet/FleetView.xaml
+++ b/ElectronicObserver/Window/Wpf/Fleet/FleetView.xaml
@@ -190,6 +190,10 @@
 										<ContentControl Grid.Column="2" Content="{Binding Equipment}" />
 									</Grid>
 								</DataTemplate>
+
+								<Style TargetType="TextBlock">
+									<Setter Property="TextWrapping" Value="Wrap" />
+								</Style>
 							</StackPanel.Resources>
 
 							<TextBlock Text="{Binding Name.ToolTip}" />

--- a/ElectronicObserver/Window/Wpf/FleetOverview/FleetOverviewView.xaml
+++ b/ElectronicObserver/Window/Wpf/FleetOverview/FleetOverviewView.xaml
@@ -123,6 +123,10 @@
 											<ContentControl Grid.Column="2" Content="{Binding Equipment}" />
 										</Grid>
 									</DataTemplate>
+
+									<Style TargetType="TextBlock">
+										<Setter Property="TextWrapping" Value="Wrap" />
+									</Style>
 								</StackPanel.Resources>
 
 								<TextBlock Text="{Binding ToolTip}" />


### PR DESCRIPTION
- We could use text wrapping to fix #442 
- I didn't test the fix with combined fleet yet