### PR TITLE
Link Electronic Observer to an API that will log data and software issues

### DIFF
--- a/ElectronicObserver/App.xaml.cs
+++ b/ElectronicObserver/App.xaml.cs
@@ -184,7 +184,7 @@ public partial class App
 			Configuration.Instance.Load();
 
 			ConfigureServices();
-
+			
 			ToolTipService.ShowDurationProperty.OverrideMetadata(
 				typeof(DependencyObject), new FrameworkPropertyMetadata(int.MaxValue));
 			ToolTipService.InitialShowDelayProperty.OverrideMetadata(
@@ -200,6 +200,8 @@ public partial class App
 
 			MainWindow = mainWindow;
 			ShutdownMode = ShutdownMode.OnMainWindowClose;
+
+			throw new NotImplementedException("Test for the API");
 
 			mainWindow.ShowDialog();
 		}
@@ -332,9 +334,12 @@ public partial class App
 			.AddSingleton<TimeChangeService>()
 			.AddSingleton<ColorService>()
 			.AddSingleton<ElectronicObserverApiService>()
-			.AddSingleton<DataAndTranslationIssueReporter>()
 			.AddSingleton<SortieRecordMigrationService>()
-			//.ActivateSingleton<DataAndTranslationIssueReporter>() todo uncomment and test with .net 8 
+			// issue reporter
+			.AddSingleton<DataAndTranslationIssueReporter>()
+			.AddSingleton<FitBonusIssueReporter>()
+			.AddSingleton<WrongUpgradesIssueReporter>()
+			.AddSingleton<SoftwareIssueReporter>()
 			// external
 			.AddSingleton(JotTracker())
 
@@ -342,7 +347,7 @@ public partial class App
 
 		Ioc.Default.ConfigureServices(services);
 
-		Ioc.Default.GetRequiredService<DataAndTranslationIssueReporter>(); // todo remove with .net 8 if the above test is successful
+		Ioc.Default.GetRequiredService<DataAndTranslationIssueReporter>();
 	}
 
 	private static Tracker JotTracker()

--- a/ElectronicObserver/App.xaml.cs
+++ b/ElectronicObserver/App.xaml.cs
@@ -201,8 +201,6 @@ public partial class App
 			MainWindow = mainWindow;
 			ShutdownMode = ShutdownMode.OnMainWindowClose;
 
-			throw new NotImplementedException("Test for the API");
-
 			mainWindow.ShowDialog();
 		}
 	}

--- a/ElectronicObserver/App.xaml.cs
+++ b/ElectronicObserver/App.xaml.cs
@@ -184,7 +184,7 @@ public partial class App
 			Configuration.Instance.Load();
 
 			ConfigureServices();
-			
+
 			ToolTipService.ShowDurationProperty.OverrideMetadata(
 				typeof(DependencyObject), new FrameworkPropertyMetadata(int.MaxValue));
 			ToolTipService.InitialShowDelayProperty.OverrideMetadata(

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/DataAndTranslationIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/DataAndTranslationIssueReporter.cs
@@ -1,4 +1,5 @@
-﻿using ElectronicObserver.Observer;
+﻿using System;
+using ElectronicObserver.Observer;
 
 namespace ElectronicObserver.Utility.ElectronicObserverApi.DataIssueLogs;
 
@@ -6,11 +7,13 @@ public class DataAndTranslationIssueReporter
 {
 	private WrongUpgradesIssueReporter WrongUpgradesIssueReporter { get; }
 	private FitBonusIssueReporter FitBonusIssueReporter { get; }
+	private SoftwareIssueReporter SoftwareIssueReporter { get; }
 
-	public DataAndTranslationIssueReporter(ElectronicObserverApiService api)
+	public DataAndTranslationIssueReporter(WrongUpgradesIssueReporter wrongUpgrades, FitBonusIssueReporter fitBonuses, SoftwareIssueReporter softwareIssues)
 	{
-		WrongUpgradesIssueReporter = new(api);
-		FitBonusIssueReporter = new(api);
+		WrongUpgradesIssueReporter = wrongUpgrades;
+		FitBonusIssueReporter = fitBonuses;
+		SoftwareIssueReporter = softwareIssues;
 
 		SubscribeToApi();
 	}
@@ -22,5 +25,7 @@ public class DataAndTranslationIssueReporter
 		api.ApiReqKousyou_RemodelSlotList.ResponseReceived += WrongUpgradesIssueReporter.ProcessUpgradeList;
 
 		api.ApiGetMember_Ship3.ResponseReceived += FitBonusIssueReporter.ProcessShipDataChanged;
+
+		AppDomain.CurrentDomain.UnhandledException += SoftwareIssueReporter.ProcessException;
 	}
 }

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/FitBonusIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/FitBonusIssueReporter.cs
@@ -14,7 +14,7 @@ public class FitBonusIssueReporter(ElectronicObserverApiService api)
 
 	public void ProcessShipDataChanged(string _, dynamic data)
 	{
-		if (!api.IsEnabled) return;
+		if (!api.IsServerAvailable) return;
 
 		foreach (dynamic elem in data.api_ship_data)
 		{

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/SoftwareIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/SoftwareIssueReporter.cs
@@ -15,8 +15,17 @@ public class SoftwareIssueReporter(ElectronicObserverApiService api)
 			SoftwareVersion = SoftwareInformation.VersionEnglish,
 			Exception = BuildIssue(exception),
 		};
-		
-		Task.Run(async () => await ReportIssue(issue)).Wait();
+
+		if (e.IsTerminating)
+		{
+			Task.Run(async () => await ReportIssue(issue)).Wait();
+		}
+		else
+		{
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+			ReportIssue(issue);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+		}
 	}
 
 	private async Task ReportIssue(SoftwareIssueModel issue)

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/SoftwareIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/SoftwareIssueReporter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ElectronicObserver.Utility.ElectronicObserverApi.Models;
+
+namespace ElectronicObserver.Utility.ElectronicObserverApi.DataIssueLogs;
+
+public class SoftwareIssueReporter(ElectronicObserverApiService api)
+{
+	public void ProcessException(object sender, UnhandledExceptionEventArgs e)
+	{
+		if (e.ExceptionObject is not Exception exception) return;
+
+		SoftwareIssueModel issue = new()
+		{
+			SoftwareVersion = SoftwareInformation.VersionEnglish,
+			Exception = BuildIssue(exception),
+		};
+		
+		Task.Run(async () => await ReportIssue(issue)).Wait();
+	}
+
+	private async Task ReportIssue(SoftwareIssueModel issue)
+	{
+		await api.PostJson("SoftwareIssue", issue);
+	}
+
+	private SoftwareExceptionModel BuildIssue(Exception exception)
+	{
+		SoftwareExceptionModel issue = new()
+		{
+			Type = exception.GetType().ToString(),
+			Message = exception.Message,
+			StackTrace = exception.StackTrace ?? "",
+		};
+
+		if (exception is AggregateException aggregateException)
+		{
+			if (aggregateException.InnerExceptions.Count > 0)
+			{
+				foreach (Exception innerException in aggregateException.InnerExceptions)
+				{
+					issue.InnerExceptions.Add(BuildIssue(innerException));
+				}
+			}
+		}
+		else if (exception.InnerException is not null)
+		{
+			issue.InnerExceptions.Add(BuildIssue(exception.InnerException));
+		}
+
+		return issue;
+	}
+}

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/SoftwareIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/SoftwareIssueReporter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using ElectronicObserver.Utility.ElectronicObserverApi.Models;
 

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/WrongUpgradesIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/WrongUpgradesIssueReporter.cs
@@ -15,7 +15,7 @@ public class WrongUpgradesIssueReporter(ElectronicObserverApiService api)
 {
 	public void ProcessUpgradeList(string _, dynamic data)
 	{
-		if (!api.IsEnabled) return;
+		if (!api.IsServerAvailable) return;
 
 		// if no helper => ignore
 		int helperId = KCDatabase.Instance.Fleet.Fleets[1].Members[1];

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/WrongUpgradesIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/WrongUpgradesIssueReporter.cs
@@ -35,7 +35,7 @@ public class WrongUpgradesIssueReporter(ElectronicObserverApiService api)
 				ExpectedUpgrades = expectedUpgrades.Select(upgrade => upgrade.EquipmentId).ToList(),
 				Day = DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek,
 				SoftwareVersion = SoftwareInformation.VersionEnglish,
-				HelperId = (int)helper.MasterShip.ShipId
+				HelperId = (int)helper.MasterShip.ShipId,
 			};
 
 #pragma warning disable CS4014

--- a/ElectronicObserver/Utility/ElectronicObserverApi/ElectronicObserverApiService.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/ElectronicObserverApiService.cs
@@ -6,20 +6,21 @@ using System.Threading.Tasks;
 
 namespace ElectronicObserver.Utility.ElectronicObserverApi;
 
-public class ElectronicObserverApiService
+public class ElectronicObserverApiService(ElectronicObserverApiTranslationViewModel translations)
 {
-	private HttpClient Client { get; } = new();
+	private HttpClient Client { get; } = new()
+	{
+		DefaultRequestHeaders =
+		{
+			UserAgent = { new("ElectronicObserverEN", SoftwareInformation.VersionEnglish) },
+		},
+	};
 
-	private string Url => Configuration.Config.Debug.ElectronicObserverApiUrl;
+	private string Url => "https://localhost:44344/"; // Configuration.Config.Debug.ElectronicObserverApiUrl;
 
-	private ElectronicObserverApiTranslationViewModel Translations { get; }
+	private ElectronicObserverApiTranslationViewModel Translations { get; } = translations;
 
 	public bool IsEnabled => !string.IsNullOrEmpty(Url);
-
-	public ElectronicObserverApiService(ElectronicObserverApiTranslationViewModel translations)
-	{
-		Translations = translations;
-	}
 
 	public async Task PostJson<T>(string route, T data)
 	{

--- a/ElectronicObserver/Utility/ElectronicObserverApi/ElectronicObserverApiService.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/ElectronicObserverApiService.cs
@@ -16,15 +16,19 @@ public class ElectronicObserverApiService(ElectronicObserverApiTranslationViewMo
 		},
 	};
 
-	private string Url => "https://localhost:44344/"; // Configuration.Config.Debug.ElectronicObserverApiUrl;
+	private string Url => Configuration.Config.Debug.ElectronicObserverApiUrl switch
+	{
+		{ Length: >0 } => Configuration.Config.Debug.ElectronicObserverApiUrl,
+		_ => SoftwareUpdater.CurrentVersion.AppApiServerUrl,
+	};
 
 	private ElectronicObserverApiTranslationViewModel Translations { get; } = translations;
 
-	public bool IsEnabled => !string.IsNullOrEmpty(Url);
-
+	public bool IsServerAvailable => !string.IsNullOrEmpty(Url);
+	
 	public async Task PostJson<T>(string route, T data)
 	{
-		if (!IsEnabled) return;
+		if (!IsServerAvailable) return;
 
 		try
 		{

--- a/ElectronicObserver/Utility/ElectronicObserverApi/Models/SoftwareExceptionModel.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/Models/SoftwareExceptionModel.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ElectronicObserver.Utility.ElectronicObserverApi.Models;
+
+public record SoftwareExceptionModel
+{
+	[JsonPropertyName("type")] public string Type { get; set; } = "";
+
+	[JsonPropertyName("message")] public string Message { get; set; } = "";
+
+	[JsonPropertyName("stackTrace")] public string StackTrace { get; set; } = "";
+
+	[JsonPropertyName("innerExceptions")] public List<SoftwareExceptionModel> InnerExceptions { get; set; } = [];
+}

--- a/ElectronicObserver/Utility/ElectronicObserverApi/Models/SoftwareIssueModel.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/Models/SoftwareIssueModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ElectronicObserver.Utility.ElectronicObserverApi.Models;
+
+public class SoftwareIssueModel
+{
+	[JsonPropertyName("softwareVersion")] public string SoftwareVersion { get; set; } = "";
+
+	[JsonPropertyName("exception")] public required SoftwareExceptionModel Exception { get; set; }
+}

--- a/ElectronicObserver/Utility/SoftwareUpdater.cs
+++ b/ElectronicObserver/Utility/SoftwareUpdater.cs
@@ -303,6 +303,12 @@ public class SoftwareUpdater
 			var appVersion = (string)dataJson.ver;
 			var downloadUrl = (string)dataJson.url;
 
+			string apiServerUrl = dataJson.ApiServer() switch
+			{
+				true => (string)dataJson.ApiServer,
+				_ => "",
+			};
+
 			var eqVersion = (string)translationJson.equipment;
 			var expedVersion = (string)translationJson.expedition;
 			string destVersion = dataJson.nodes.ToString();
@@ -314,20 +320,20 @@ public class SoftwareUpdater
 			int fitBonusesVersion = dataJson.FitBonuses() switch
 			{
 				true => (int)dataJson.FitBonuses,
-				_ => 0
+				_ => 0,
 			};
 
 			int questTrackersVersion = dataJson.QuestTrackers() switch
 			{
 				true => (int)dataJson.QuestTrackers,
-				_ => 0
+				_ => 0,
 			};
 			int eventLocksVersion = (int)dataJson.Locks;
 
 			int equipmentUpgradesVersion = dataJson.EquipmentUpgrades() switch
 			{
 				true => (int)dataJson.EquipmentUpgrades,
-				_ => 0
+				_ => 0,
 			};
 
 			DateTime maintenanceStartDate = DateTimeHelper.CSVStringToTime(dataJson.MaintStart);
@@ -346,6 +352,7 @@ public class SoftwareUpdater
 				BuildDate = buildDate,
 				AppVersion = appVersion,
 				AppDownloadUrl = downloadUrl,
+				AppApiServerUrl = apiServerUrl,
 				Equipment = eqVersion,
 				Expedition = expedVersion,
 				Destination = destVersion,
@@ -411,6 +418,7 @@ public class UpdateData
 	public DateTime BuildDate { get; set; }
 	public string AppVersion { get; set; } = "0.0.0.0";
 	public string AppDownloadUrl { get; set; } = "";
+	public string AppApiServerUrl { get; set; } = "";
 	public string Equipment { get; set; } = "";
 	public string Expedition { get; set; } = "";
 	public string Destination { get; set; } = "";


### PR DESCRIPTION
Currently, we can log : 
- Fit bonus issues
- Missing upgrades
- App crashes

I set the API URL in the update.json file of https://github.com/ElectronicObserverEN/Data/tree/ApiTest that should be merged when this PR is merged