### PR TITLE
Local api loader improvements

### DIFF
--- a/ElectronicObserver/Data/KCDatabase.cs
+++ b/ElectronicObserver/Data/KCDatabase.cs
@@ -1,4 +1,5 @@
-﻿using ElectronicObserver.Data.Battle;
+﻿using DynaJson;
+using ElectronicObserver.Data.Battle;
 using ElectronicObserver.Data.Quest;
 using ElectronicObserver.Data.Translation;
 using ElectronicObserver.Data.TsunDbSubmission;
@@ -206,8 +207,53 @@ public sealed class KCDatabase : IKCDatabase
 		TsunDbSubmission = new TsunDbSubmissionManager();
 		FleetPreset = new FleetPresetManager();
 		Translation = new DataAndTranslationManager();
+
+#if DEBUG
+		// data needed for loading old event battles via local api loader
+		// the values don't really matter, they just need to exist
+		AddWorld("""{"api_id":56,"api_name":"","api_type":1}""");
+		AddWorld("""{"api_id":57,"api_name":"","api_type":1}""");
+		AddWorld("""{"api_id":58,"api_name":"","api_type":1}""");
+
+		AddMap("""{"api_id":561,"api_maparea_id":56,"api_no":1,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":562,"api_maparea_id":56,"api_no":2,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":563,"api_maparea_id":56,"api_no":3,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":564,"api_maparea_id":56,"api_no":4,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":565,"api_maparea_id":56,"api_no":5,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":566,"api_maparea_id":56,"api_no":6,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		
+		AddMap("""{"api_id":571,"api_maparea_id":57,"api_no":1,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":572,"api_maparea_id":57,"api_no":2,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":573,"api_maparea_id":57,"api_no":3,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":574,"api_maparea_id":57,"api_no":4,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":575,"api_maparea_id":57,"api_no":5,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":576,"api_maparea_id":57,"api_no":6,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":577,"api_maparea_id":57,"api_no":7,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		
+		AddMap("""{"api_id":581,"api_maparea_id":58,"api_no":1,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":582,"api_maparea_id":58,"api_no":2,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":583,"api_maparea_id":58,"api_no":3,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		AddMap("""{"api_id":584,"api_maparea_id":58,"api_no":4,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+#endif
 	}
 
+	private void AddWorld(string json)
+	{
+		dynamic elem = JsonObject.Parse(json);
+
+		MapAreaData item = new();
+		item.LoadFromResponse("api_start2/getData", elem);
+		MapArea.Add(item);
+	}
+
+	private void AddMap(string json)
+	{
+		dynamic elem = JsonObject.Parse(json);
+
+		MapInfoData item = new();
+		item.LoadFromResponse("api_start2/getData", elem);
+		MapInfo.Add(item);
+	}
 
 	public void Load()
 	{

--- a/ElectronicObserver/Data/KCDatabase.cs
+++ b/ElectronicObserver/Data/KCDatabase.cs
@@ -211,43 +211,31 @@ public sealed class KCDatabase : IKCDatabase
 #if DEBUG
 		// data needed for loading old event battles via local api loader
 		// the values don't really matter, they just need to exist
-		AddWorld("""{"api_id":56,"api_name":"","api_type":1}""");
-		AddWorld("""{"api_id":57,"api_name":"","api_type":1}""");
-		AddWorld("""{"api_id":58,"api_name":"","api_type":1}""");
-
-		AddMap("""{"api_id":561,"api_maparea_id":56,"api_no":1,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":562,"api_maparea_id":56,"api_no":2,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":563,"api_maparea_id":56,"api_no":3,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":564,"api_maparea_id":56,"api_no":4,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":565,"api_maparea_id":56,"api_no":5,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":566,"api_maparea_id":56,"api_no":6,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		
-		AddMap("""{"api_id":571,"api_maparea_id":57,"api_no":1,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":572,"api_maparea_id":57,"api_no":2,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":573,"api_maparea_id":57,"api_no":3,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":574,"api_maparea_id":57,"api_no":4,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":575,"api_maparea_id":57,"api_no":5,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":576,"api_maparea_id":57,"api_no":6,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":577,"api_maparea_id":57,"api_no":7,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		
-		AddMap("""{"api_id":581,"api_maparea_id":58,"api_no":1,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":582,"api_maparea_id":58,"api_no":2,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":583,"api_maparea_id":58,"api_no":3,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
-		AddMap("""{"api_id":584,"api_maparea_id":58,"api_no":4,"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""");
+		for (int i = 56; i <= 59; i++)
+		{
+			AddWorld(i);
+		}
 #endif
 	}
 
-	private void AddWorld(string json)
+	private void AddWorld(int world)
 	{
+		string json = $$"""{"api_id":{{world}},"api_name":"","api_type":1}""";
 		dynamic elem = JsonObject.Parse(json);
 
 		MapAreaData item = new();
 		item.LoadFromResponse("api_start2/getData", elem);
 		MapArea.Add(item);
+
+		for (int i = 1; i <= 7; i++)
+		{
+			AddMap(world, i);
+		}
 	}
 
-	private void AddMap(string json)
+	private void AddMap(int world, int map)
 	{
+		string json = $$"""{"api_id":{{world}}{{map}},"api_maparea_id":{{world}},"api_no":{{map}},"api_name":"","api_level":6,"api_opetext":"","api_infotext":"","api_item":[32,34,0,0],"api_max_maphp":300,"api_required_defeat_count":null,"api_sally_flag":[1,0,0]}""";
 		dynamic elem = JsonObject.Parse(json);
 
 		MapInfoData item = new();

--- a/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
+++ b/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
@@ -358,7 +358,7 @@ public partial class DialogLocalAPILoader2 : Form
 		Action<string> act = SortieRecord switch
 		{
 			null => ExecuteAPI,
-			_ => ExecuteSortieRecordApi
+			_ => ExecuteSortieRecordApi,
 		};
 
 		foreach (string? file in files)

--- a/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
+++ b/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
@@ -189,7 +189,7 @@ public partial class DialogLocalAPILoader2 : Form
 
 	private void LoadSortieRecordFiles(SortieRecord sortieRecord)
 	{
-		if (!sortieRecord.ApiFiles.Any()) return;
+		if (sortieRecord.ApiFiles.Count is 0) return;
 
 		APIView.Rows.Clear();
 
@@ -332,8 +332,6 @@ public partial class DialogLocalAPILoader2 : Form
 
 				apiFile.Content = JsonSerializer.Serialize(apiFilePortResponse, JsonSerializerOptions);
 			}
-
-			// apiFile.Content = apiFile.Content.Replace("\"api_plane_info\":null,", "");
 		}
 
 		switch (apiFileType)

--- a/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
+++ b/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
@@ -4,15 +4,28 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using System.Windows.Forms;
+using ElectronicObserver.Database;
+using ElectronicObserver.Database.KancolleApi;
+using ElectronicObserver.Database.Sortie;
+using ElectronicObserver.KancolleApi.Types;
+using ElectronicObserver.KancolleApi.Types.ApiPort.Port;
+using ElectronicObserver.KancolleApi.Types.Models;
 using ElectronicObserver.Observer;
+using ElectronicObserver.Utility;
 using ElectronicObserver.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using static Org.BouncyCastle.Math.EC.ECCurve;
 
 namespace ElectronicObserver.Window.Dialog;
 
 public partial class DialogLocalAPILoader2 : Form
 {
-
+	private SortieRecord? SortieRecord { get; }
+	private List<ApiFile> ApiFilesBeforeSortie { get; set; } = [];
 
 	private string CurrentPath { get; set; }
 
@@ -22,6 +35,11 @@ public partial class DialogLocalAPILoader2 : Form
 		InitializeComponent();
 
 		Translate();
+	}
+
+	public DialogLocalAPILoader2(SortieRecord sortieRecord) : this()
+	{
+		SortieRecord = sortieRecord;
 	}
 
 	public void Translate()
@@ -44,7 +62,14 @@ public partial class DialogLocalAPILoader2 : Form
 
 	private void DialogLocalAPILoader2_Load(object sender, EventArgs e)
 	{
-		LoadFiles(Utility.Configuration.Config.Connection.SaveDataPath);
+		if (SortieRecord is null)
+		{
+			LoadFiles(Utility.Configuration.Config.Connection.SaveDataPath);
+		}
+		else
+		{
+			LoadSortieRecordFiles(SortieRecord);
+		}
 	}
 
 
@@ -101,14 +126,19 @@ public partial class DialogLocalAPILoader2 : Form
 
 	private void ButtonExecuteNext_Click(object sender, EventArgs e)
 	{
-
 		if (APIView.SelectedRows.Count == 1)
 		{
-
-			var row = APIView.SelectedRows[0];
+			DataGridViewRow row = APIView.SelectedRows[0];
 			int index = APIView.SelectedRows[0].Index;
 
-			ExecuteAPI((string)row.Cells[APIView_FileName.Index].Value);
+			if (SortieRecord is null)
+			{
+				ExecuteAPI((string)row.Cells[APIView_FileName.Index].Value);
+			}
+			else
+			{
+				ExecuteSortieRecordApi((string)row.Cells[APIView_FileName.Index].Value);
+			}
 
 			APIView.ClearSelection();
 			if (index < APIView.Rows.Count - 1)
@@ -150,6 +180,45 @@ public partial class DialogLocalAPILoader2 : Form
 		}
 
 		APIView.Rows.AddRange(rows.ToArray());
+		APIView.Sort(APIView_FileName, ListSortDirection.Ascending);
+
+	}
+
+	private void LoadSortieRecordFiles(SortieRecord sortieRecord)
+	{
+		if (!sortieRecord.ApiFiles.Any()) return;
+
+		APIView.Rows.Clear();
+
+		List<DataGridViewRow> rows = [];
+
+		int firstSortieApiFileId = sortieRecord.ApiFiles.MinBy(f => f.Id)!.Id;
+
+		ElectronicObserverContext db = new();
+		db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+		int lastPortFileIdBeforeSortieId = db.ApiFiles
+			.Where(f => f.Id < firstSortieApiFileId)
+			.Where(f => f.Name == "api_port/port")
+			.OrderByDescending(f => f.Id)
+			.First()
+			.Id;
+
+		ApiFilesBeforeSortie = db.ApiFiles
+			.Where(f => f.Id < firstSortieApiFileId)
+			.Where(f => f.Id >= lastPortFileIdBeforeSortieId)
+			.ToList();
+
+		foreach (string file in ApiFilesBeforeSortie.Concat(sortieRecord.ApiFiles).Select(f => $"{f.Id} {f.ApiFileType} {f.Name}"))
+		{
+			DataGridViewRow row = new();
+			row.CreateCells(APIView);
+
+			row.SetValues(file);
+			rows.Add(row);
+		}
+
+		APIView.Rows.AddRange([.. rows]);
 		APIView.Sort(APIView_FileName, ListSortDirection.Ascending);
 
 	}
@@ -211,15 +280,92 @@ public partial class DialogLocalAPILoader2 : Form
 
 	}
 
+	private void ExecuteSortieRecordApi(string filename)
+	{
+		Debug.Assert(SortieRecord is not null);
 
+		string[] values = filename.Split(" ");
+
+		int recordId = int.Parse(values[0]);
+		ApiFileType apiFileType = Enum.Parse<ApiFileType>(values[1]);
+		string apiName = values[2];
+
+		if (!APIObserver.Instance.APIList.ContainsKey(apiName)) return;
+
+		ApiFile apiFile = ApiFilesBeforeSortie.Concat(SortieRecord.ApiFiles).First(f => f.Id == recordId);
+
+		if (apiFile.Name is "api_port/port")
+		{
+			string? savedPortResponseJson = LoadApiResponse("api_port/port");
+
+			if (savedPortResponseJson is not null)
+			{
+				ApiResponse<ApiPortPortResponse> savedPortResponse = JsonSerializer
+					.Deserialize<ApiResponse<ApiPortPortResponse>>(savedPortResponseJson[7..])
+					?? throw new NotImplementedException();
+
+				ApiResponse<ApiPortPortResponse> apiFilePortResponse = JsonSerializer
+					.Deserialize<ApiResponse<ApiPortPortResponse>>(apiFile.Content)
+					?? throw new NotImplementedException();
+
+				apiFilePortResponse.ApiData.ApiShip = savedPortResponse.ApiData.ApiShip;
+				apiFilePortResponse.ApiData.ApiLog = savedPortResponse.ApiData.ApiLog;
+				apiFilePortResponse.ApiData.ApiNdock = savedPortResponse.ApiData.ApiNdock;
+
+				apiFilePortResponse.ApiData.ApiDeckPort = SortieRecord.FleetData.Fleets
+					.Select((f, i) => f switch
+					{
+						null => null,
+
+						_ => new FleetDataDto
+						{
+							ApiId = i + 1,
+							ApiShip = f.Ships.Select(s => s.DropId ?? 0).ToList(),
+							ApiMission = [0, 0, 0, 0],
+						},
+					})
+					.OfType<FleetDataDto>()
+					.ToList();
+
+				JsonSerializerOptions options = new()
+				{
+					DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+				};
+
+				apiFile.Content = JsonSerializer.Serialize(apiFilePortResponse, options);
+			}
+
+			// apiFile.Content = apiFile.Content.Replace("\"api_plane_info\":null,", "");
+		}
+
+		switch (apiFileType)
+		{
+			case ApiFileType.Request:
+				Dictionary<string, string> queryParameters = JsonSerializer
+					.Deserialize<Dictionary<string, string>>(apiFile.Content)
+					?? throw new NotImplementedException();
+
+				string queryString = string.Join("&", queryParameters.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+				APIObserver.Instance.LoadRequest("/kcsapi/" + apiName, queryString);
+				break;
+
+			case ApiFileType.Response:
+				APIObserver.Instance.LoadResponse("/kcsapi/" + apiName, $"svdata={apiFile.Content}");
+				break;
+		}
+	}
 
 	private void APICaller_DoWork(object sender, DoWorkEventArgs e)
 	{
+		if (e.Argument is not IEnumerable<string?> files) return;
 
-		var files = e.Argument as IOrderedEnumerable<string>;
-		var act = new Action<string>(ExecuteAPI);
+		Action<string> act = SortieRecord switch
+		{
+			null => ExecuteAPI,
+			_ => ExecuteSortieRecordApi
+		};
 
-		foreach (var file in files)
+		foreach (string? file in files)
 		{
 			Invoke(act, file);
 			System.Threading.Thread.Sleep(10);      //ゆるして
@@ -375,7 +521,7 @@ public partial class DialogLocalAPILoader2 : Form
 	{
 		try
 		{
-			ProcessStartInfo psi = new ProcessStartInfo
+			ProcessStartInfo psi = new()
 			{
 				FileName = CurrentPath + "\\" + APIView.SelectedCells.OfType<DataGridViewCell>().First().Value,
 				UseShellExecute = true
@@ -386,5 +532,19 @@ public partial class DialogLocalAPILoader2 : Form
 		{
 			Utility.Logger.Add(1, string.Format(LocalAPILoader2Resources.FailedToStart, ex.GetType().Name, ex.Message));
 		}
+	}
+
+	private string? LoadApiResponse(string apiName)
+	{
+		Configuration.ConfigurationData Config = Configuration.Config;
+
+		if (string.IsNullOrEmpty(Config.Connection.SaveDataPath)) return null;
+		if (!Directory.Exists(Config.Connection.SaveDataPath)) return null;
+
+		string filePath = Path.Combine(Config.Connection.SaveDataPath, "kcsapi", apiName);
+
+		if (!File.Exists(filePath)) return null;
+
+		return File.ReadAllText(filePath);
 	}
 }

--- a/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
+++ b/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
@@ -530,14 +530,14 @@ public partial class DialogLocalAPILoader2 : Form
 		}
 	}
 
-	private string? LoadApiResponse(string apiName)
+	private static string? LoadApiResponse(string apiName)
 	{
-		Configuration.ConfigurationData Config = Configuration.Config;
+		Configuration.ConfigurationData config = Configuration.Config;
 
-		if (string.IsNullOrEmpty(Config.Connection.SaveDataPath)) return null;
-		if (!Directory.Exists(Config.Connection.SaveDataPath)) return null;
+		if (string.IsNullOrEmpty(config.Connection.SaveDataPath)) return null;
+		if (!Directory.Exists(config.Connection.SaveDataPath)) return null;
 
-		string filePath = Path.Combine(Config.Connection.SaveDataPath, "kcsapi", apiName);
+		string filePath = Path.Combine(config.Connection.SaveDataPath, "kcsapi", apiName);
 
 		if (!File.Exists(filePath)) return null;
 

--- a/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
+++ b/ElectronicObserver/Window/Dialog/DialogLocalAPILoader2.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using ElectronicObserver.Database;
 using ElectronicObserver.Database.KancolleApi;
@@ -18,12 +17,16 @@ using ElectronicObserver.Observer;
 using ElectronicObserver.Utility;
 using ElectronicObserver.ViewModels;
 using Microsoft.EntityFrameworkCore;
-using static Org.BouncyCastle.Math.EC.ECCurve;
 
 namespace ElectronicObserver.Window.Dialog;
 
 public partial class DialogLocalAPILoader2 : Form
 {
+	private JsonSerializerOptions JsonSerializerOptions { get; } = new()
+	{
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	};
+
 	private SortieRecord? SortieRecord { get; }
 	private List<ApiFile> ApiFilesBeforeSortie { get; set; } = [];
 
@@ -327,12 +330,7 @@ public partial class DialogLocalAPILoader2 : Form
 					.OfType<FleetDataDto>()
 					.ToList();
 
-				JsonSerializerOptions options = new()
-				{
-					DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-				};
-
-				apiFile.Content = JsonSerializer.Serialize(apiFilePortResponse, options);
+				apiFile.Content = JsonSerializer.Serialize(apiFilePortResponse, JsonSerializerOptions);
 			}
 
 			// apiFile.Content = apiFile.Content.Replace("\"api_plane_info\":null,", "");

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
@@ -23,6 +23,8 @@ using ElectronicObserver.Database;
 using ElectronicObserver.Database.DataMigration;
 using ElectronicObserver.Services;
 using ElectronicObserver.Utility;
+using ElectronicObserver.ViewModels;
+using ElectronicObserver.Window.Dialog;
 using ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 using ElectronicObserver.Window.Tools.SortieRecordViewer.SortieCostViewer;
 using Microsoft.EntityFrameworkCore;
@@ -470,5 +472,15 @@ public partial class SortieRecordViewerViewModel : WindowViewModelBase
 		SortieCostViewerViewModel sortieCost = new(Db, ToolService, SortieRecordMigrationService, SelectedSorties, SortieCostConfiguration);
 
 		new SortieCostViewerWindow(sortieCost).Show();
+	}
+
+	[RelayCommand]
+	private async Task OpenLocalApiLoader()
+	{
+		if (SelectedSortie is null) return;
+
+		await SelectedSortie.Model.EnsureApiFilesLoaded(Db);
+
+		new DialogLocalAPILoader2(SelectedSortie.Model).Show();
 	}
 }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
@@ -23,7 +23,6 @@ using ElectronicObserver.Database;
 using ElectronicObserver.Database.DataMigration;
 using ElectronicObserver.Services;
 using ElectronicObserver.Utility;
-using ElectronicObserver.ViewModels;
 using ElectronicObserver.Window.Dialog;
 using ElectronicObserver.Window.Tools.SortieRecordViewer.DataExport;
 using ElectronicObserver.Window.Tools.SortieRecordViewer.SortieCostViewer;

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
@@ -78,6 +78,13 @@ public partial class SortieRecordViewerViewModel : WindowViewModelBase
 
 	private SortieCostConfigurationViewModel SortieCostConfiguration { get; } = new();
 
+	public bool IsDebug =>
+#if DEBUG
+		true;
+#else
+		false;
+#endif
+
 	public SortieRecordViewerViewModel()
 	{
 		ToolService = Ioc.Default.GetRequiredService<ToolService>();
@@ -476,6 +483,7 @@ public partial class SortieRecordViewerViewModel : WindowViewModelBase
 	[RelayCommand]
 	private async Task OpenLocalApiLoader()
 	{
+		if (!IsDebug) return;
 		if (SelectedSortie is null) return;
 
 		await SelectedSortie.Model.EnsureApiFilesLoaded(Db);

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerWindow.xaml
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerWindow.xaml
@@ -194,7 +194,11 @@
 							<MenuItem Command="{Binding CopySmokerDataCsvCommand}" Header="{Binding SortieRecordViewer.SmokeScreenCsv}" />
 							<MenuItem Command="{Binding ExportBattleRanksCommand}" Header="{x:Static translations:CsvExportResources.CombatRankPrediction}" />
 						</MenuItem>
-						<MenuItem Command="{Binding OpenLocalApiLoaderCommand}" Header="Local api loader" />
+						<MenuItem
+							Command="{Binding OpenLocalApiLoaderCommand}"
+							Header="Local api loader"
+							Visibility="{Binding IsDebug, Converter={StaticResource BooleanToVisibilityConverter}}"
+							/>
 					</ContextMenu>
 				</DataGrid.ContextMenu>
 

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerWindow.xaml
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerWindow.xaml
@@ -194,6 +194,7 @@
 							<MenuItem Command="{Binding CopySmokerDataCsvCommand}" Header="{Binding SortieRecordViewer.SmokeScreenCsv}" />
 							<MenuItem Command="{Binding ExportBattleRanksCommand}" Header="{x:Static translations:CsvExportResources.CombatRankPrediction}" />
 						</MenuItem>
+						<MenuItem Command="{Binding OpenLocalApiLoaderCommand}" Header="Local api loader" />
 					</ContextMenu>
 				</DataGrid.ContextMenu>
 


### PR DESCRIPTION
Older data might not work totally as expected, because it's using the current ship/equipment data trying to simulate what happened during the sortie, meaning if you don't have the exact ship/equipment anymore, it can break stuff.
The missing data can be reconstructed, but it's a lot of work and technically isn't needed for the current use case, which is mainly for #484 testing.

Data from before the opening torpedo rework won't work either till #484 is merged. That should come after this PR is merged.