### PR TITLE
Upgrade cost can depend on the day

### DIFF
--- a/ElectronicObserver/Utility/Data/EquipmentUpgradeCostExtensions.cs
+++ b/ElectronicObserver/Utility/Data/EquipmentUpgradeCostExtensions.cs
@@ -9,6 +9,9 @@ namespace ElectronicObserver.Utility.Data;
 public static class EquipmentUpgradeCostExtensions
 {
 	public static EquipmentUpgradePlanCostModel CalculateUpgradeCost(this IEquipmentData equipment, List<EquipmentUpgradeDataModel> upgradesData, IShipDataMaster? helper, UpgradeLevel targetedLevel, SliderUpgradeLevel sliderLevel)
+		=> equipment.CalculateUpgradeCost(upgradesData, helper, targetedLevel, sliderLevel, null);
+
+	public static EquipmentUpgradePlanCostModel CalculateUpgradeCost(this IEquipmentData equipment, List<EquipmentUpgradeDataModel> upgradesData, IShipDataMaster? helper, UpgradeLevel targetedLevel, SliderUpgradeLevel sliderLevel, DayOfWeek? day)
 	{
 		EquipmentUpgradePlanCostModel cost = new();
 
@@ -18,7 +21,7 @@ public static class EquipmentUpgradeCostExtensions
 
 		if (upgradeData is null) return cost;
 
-		EquipmentUpgradeImprovementModel? improvementModel = GetImprovementModelDependingOnHelper(upgradeData.Improvement, helper);
+		EquipmentUpgradeImprovementModel? improvementModel = GetImprovementModelDependingOnHelperAndDay(upgradeData.Improvement, helper, day);
 
 		if (improvementModel is null) return cost;
 
@@ -37,6 +40,9 @@ public static class EquipmentUpgradeCostExtensions
 
 	public static EquipmentUpgradePlanCostModel CalculateNextUpgradeCost(this IEquipmentData equipment, List<EquipmentUpgradeDataModel> upgradesData, IShipDataMaster? helper, SliderUpgradeLevel sliderLevel)
 		=> CalculateUpgradeCost(equipment, upgradesData, helper, equipment.UpgradeLevel.GetNextLevel(), sliderLevel);
+
+	public static EquipmentUpgradePlanCostModel CalculateNextUpgradeCost(this IEquipmentData equipment, List<EquipmentUpgradeDataModel> upgradesData, IShipDataMaster? helper, SliderUpgradeLevel sliderLevel, DayOfWeek? day)
+		=> CalculateUpgradeCost(equipment, upgradesData, helper, equipment.UpgradeLevel.GetNextLevel(), sliderLevel, day);
 
 	public static EquipmentUpgradePlanCostModel CalculateUpgradeLevelCost(this EquipmentUpgradeImprovementModel improvementModel, UpgradeLevel level, bool useSlider)
 	{
@@ -84,11 +90,11 @@ public static class EquipmentUpgradeCostExtensions
 	/// <param name="improvements"></param>
 	/// <param name="helper"></param>
 	/// <returns></returns>
-	private static EquipmentUpgradeImprovementModel? GetImprovementModelDependingOnHelper(List<EquipmentUpgradeImprovementModel> improvements, IShipDataMaster? helper)
+	private static EquipmentUpgradeImprovementModel? GetImprovementModelDependingOnHelperAndDay(List<EquipmentUpgradeImprovementModel> improvements, IShipDataMaster? helper, DayOfWeek? day)
 	{
 		if (helper is null) return improvements.FirstOrDefault();
 
-		return improvements.FirstOrDefault(imp => imp.Helpers.SelectMany(helpers => helpers.ShipIds).ToList().Contains(helper.ShipID));
+		return improvements.FirstOrDefault(imp => imp.Helpers.Any(helpers => helpers.ShipIds.Contains(helper.ShipID) && (day is not { } dayNotNull || helpers.CanHelpOnDays.Contains(dayNotNull))));
 	}
 
 	/// <summary>

--- a/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/WrongUpgradesCostIssueReporter.cs
+++ b/ElectronicObserver/Utility/ElectronicObserverApi/DataIssueLogs/WrongUpgradesCostIssueReporter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using ElectronicObserver.Data;
@@ -6,6 +7,7 @@ using ElectronicObserver.KancolleApi.Types.ApiReqKousyou.RemodelSlotlist;
 using ElectronicObserver.KancolleApi.Types.ApiReqKousyou.RemodelSlotlistDetail;
 using ElectronicObserver.Utility.Data;
 using ElectronicObserver.Utility.ElectronicObserverApi.Models.UpgradeCosts;
+using ElectronicObserver.Utility.Mathematics;
 using ElectronicObserver.Window.Tools.EquipmentUpgradePlanner.CostCalculation;
 using ElectronicObserverTypes;
 using ElectronicObserverTypes.Serialization.EquipmentUpgrade;
@@ -65,6 +67,7 @@ public class WrongUpgradesCostIssueReporter(ElectronicObserverApiService api)
 	{
 		if (!api.IsServerAvailable) return;
 		if (!Configuration.Config.Control.UpdateRepoURL.ToString().Contains("ElectronicObserverEN")) return;
+		DayOfWeek day = DateTimeHelper.GetJapanStandardTimeNow().DayOfWeek;
 
 		if (Ship is null) return;
 		if (Equipment is null) return;
@@ -82,8 +85,8 @@ public class WrongUpgradesCostIssueReporter(ElectronicObserverApiService api)
 
 		if (!RessourcePerEquipment.TryGetValue(Equipment.EquipmentId, out APIReqKousyouRemodelSlotlistResponse? baseCostResponse)) return;
 
-		EquipmentUpgradePlanCostModel expectedCostSlider = Equipment.CalculateNextUpgradeCost(KCDatabase.Instance.Translation.EquipmentUpgrade.UpgradeList, Ship, SliderUpgradeLevel.Always);
-		EquipmentUpgradePlanCostModel expectedCostNoSlider = Equipment.CalculateNextUpgradeCost(KCDatabase.Instance.Translation.EquipmentUpgrade.UpgradeList, Ship, SliderUpgradeLevel.Never);
+		EquipmentUpgradePlanCostModel expectedCostSlider = Equipment.CalculateNextUpgradeCost(KCDatabase.Instance.Translation.EquipmentUpgrade.UpgradeList, Ship, SliderUpgradeLevel.Always, day);
+		EquipmentUpgradePlanCostModel expectedCostNoSlider = Equipment.CalculateNextUpgradeCost(KCDatabase.Instance.Translation.EquipmentUpgrade.UpgradeList, Ship, SliderUpgradeLevel.Never, day);
 		
 		// cost not found -> only report cost if the equipment has no upgrade known
 		// this is to avoid reporting cost when the issue is just that the ship can upgrade something, but the upgrade data hasn't been updated yet

--- a/ElectronicObserverCoreTests/UpgradeCostTests.cs
+++ b/ElectronicObserverCoreTests/UpgradeCostTests.cs
@@ -1,4 +1,5 @@
-﻿using ElectronicObserver.Utility.Data;
+﻿using System;
+using ElectronicObserver.Utility.Data;
 using ElectronicObserver.Window.Tools.EquipmentUpgradePlanner;
 using ElectronicObserver.Window.Tools.EquipmentUpgradePlanner.CostCalculation;
 using ElectronicObserverTypes;
@@ -41,7 +42,7 @@ public class UpgradeCostTests
 		};
 		IShipDataMaster helper = Db.MasterShips[plan.SelectedHelper];
 
-		EquipmentUpgradePlanCostModel cost = equipment.CalculateUpgradeCost(UpgradeData.UpgradeList, helper, plan.DesiredUpgradeLevel, plan.SliderLevel);
+		EquipmentUpgradePlanCostModel cost = equipment.CalculateUpgradeCost(UpgradeData.UpgradeList, helper, plan.DesiredUpgradeLevel, plan.SliderLevel, null);
 
 
 		EquipmentUpgradePlanCostModel expectedCost = new EquipmentUpgradePlanCostModel()
@@ -480,4 +481,97 @@ public class UpgradeCostTests
 		Assert.Equal(expectedCost, cost);
 	}
 
+	/// <summary>
+	/// Isuzu Kai Ni conversion changes depending on the day of the week
+	/// </summary>
+	[Fact(DisplayName = "Isuzu Kai Ni convert T93 Sonar to T3 Sonar on Monday")]
+	public void UpgradeCostTest8()
+	{
+		Assert.NotEmpty(UpgradeData.UpgradeList);
+
+		EquipmentUpgradePlanItemModel plan = new()
+		{
+			DesiredUpgradeLevel = UpgradeLevel.Conversion,
+			EquipmentId = EquipmentId.Sonar_Type93PassiveSONAR,
+			SliderLevel = SliderUpgradeLevel.Never,
+			SelectedHelper = ShipId.IsuzuKaiNi,
+		};
+
+		EquipmentDataMock equipment = new EquipmentDataMock(Db.MasterEquipment[plan.EquipmentId])
+		{
+			UpgradeLevel = UpgradeLevel.Max,
+		};
+
+		IShipDataMaster helper = Db.MasterShips[plan.SelectedHelper];
+
+		EquipmentUpgradePlanCostModel cost = equipment.CalculateUpgradeCost(UpgradeData.UpgradeList, helper, plan.DesiredUpgradeLevel, plan.SliderLevel, DayOfWeek.Monday);
+
+		EquipmentUpgradePlanCostModel expectedCost = new()
+		{
+			Fuel = 10,
+			Ammo = 0,
+			Steel = 30,
+			Bauxite = 30,
+
+			DevelopmentMaterial = 6,
+			ImprovementMaterial = 3,
+
+			RequiredEquipments = [
+				new EquipmentUpgradePlanCostItemModel()
+				{
+					Id = (int)EquipmentId.Sonar_Type93PassiveSONAR,
+					Required = 2,
+				},
+			],
+		};
+
+		Assert.Equal(expectedCost, cost);
+	}
+
+	/// <summary>
+	/// Isuzu Kai Ni conversion changes depending on the day of the week
+	/// </summary>
+	[Fact(DisplayName = "Isuzu Kai Ni convert T93 Sonar to T4 Sonar on Friday")]
+	public void UpgradeCostTest9()
+	{
+		Assert.NotEmpty(UpgradeData.UpgradeList);
+
+		EquipmentUpgradePlanItemModel plan = new()
+		{
+			DesiredUpgradeLevel = UpgradeLevel.Conversion,
+			EquipmentId = EquipmentId.Sonar_Type93PassiveSONAR,
+			SliderLevel = SliderUpgradeLevel.Never,
+			SelectedHelper = ShipId.IsuzuKaiNi,
+		};
+
+		EquipmentDataMock equipment = new EquipmentDataMock(Db.MasterEquipment[plan.EquipmentId])
+		{
+			UpgradeLevel = UpgradeLevel.Max,
+		};
+
+		IShipDataMaster helper = Db.MasterShips[plan.SelectedHelper];
+
+		EquipmentUpgradePlanCostModel cost = equipment.CalculateUpgradeCost(UpgradeData.UpgradeList, helper, plan.DesiredUpgradeLevel, plan.SliderLevel, DayOfWeek.Friday);
+
+		EquipmentUpgradePlanCostModel expectedCost = new()
+		{
+			Fuel = 10,
+			Ammo = 0,
+			Steel = 30,
+			Bauxite = 30,
+
+			DevelopmentMaterial = 10,
+			ImprovementMaterial = 6,
+
+			RequiredEquipments = [
+				new EquipmentUpgradePlanCostItemModel()
+				{
+					Id = (int)EquipmentId.Sonar_Type3ActiveSONAR,
+					Required = 2,
+				},
+			],
+		};
+
+		Assert.Equal(expectedCost, cost);
+	}
 }


### PR DESCRIPTION
This should fix the cost report false positive report, but this won's affect the costs displayed in EO. Maybe there's something to do ? 
The special case display seems fine in encyclopedia 
![image](https://github.com/user-attachments/assets/3dcdad4f-cc08-4223-93f8-36fda4cf205c)

But it's not great in planner and plan viewer, since you can't even choose which conversion you want to go with ...

![image](https://github.com/user-attachments/assets/47129c90-1ca6-429b-91c2-ea163f9a6595)

