### PR TITLE
Add extension support

### DIFF
--- a/Browser/Browser.csproj
+++ b/Browser/Browser.csproj
@@ -39,7 +39,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="CefSharp.WinForms.NETCore" Version="124.3.50" />
+		<PackageReference Include="CefSharp.WinForms.NETCore" Version="130.1.90" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="Grpc" Version="2.46.6" />
 		<PackageReference Include="Grpc.Core" Version="2.46.6" />
@@ -94,5 +94,8 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Update="chromiumembeddedframework.runtime.win-x86" Version="124.3.5" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="CefSharpBrowser\Extensions\" />
 	</ItemGroup>
 </Project>

--- a/Browser/CefSharpBrowser/CefOp/CustomRequestHandler.cs
+++ b/Browser/CefSharpBrowser/CefOp/CustomRequestHandler.cs
@@ -21,7 +21,7 @@ public class CustomRequestHandler : RequestHandler
 	{
 		BrowserConfiguration = browserConfiguration;
 	}
-
+	
 	/// <summary>
 	/// 戻る/進む操作をブロックします。
 	/// </summary>

--- a/Browser/CefSharpBrowser/CefSharpViewModel.cs
+++ b/Browser/CefSharpBrowser/CefSharpViewModel.cs
@@ -133,6 +133,7 @@ public class CefSharpViewModel : BrowserViewModel
 		}
 
 		CefSharpSettings.SubprocessExitIfParentProcessClosed = true;
+		CefSharpSettings.RuntimeStyle = CefRuntimeStyle.Chrome;
 		Cef.Initialize(settings, false, (IBrowserProcessHandler?)null);
 
 		CustomRequestHandler requestHandler = new(Configuration);

--- a/Browser/CefSharpBrowser/ExtraBrowser/ExtraBrowserWindow.xaml
+++ b/Browser/CefSharpBrowser/ExtraBrowser/ExtraBrowserWindow.xaml
@@ -42,6 +42,7 @@
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition />
 			</Grid.ColumnDefinitions>
 			<Button
@@ -64,9 +65,14 @@
 				Click="AkashiListButtonClick"
 				Content="{Binding FormBrowser.AkashiList, ElementName=ExtraBrowser}"
 				/>
+			<Button
+				Grid.Column="4"
+				Click="ExtensionButtonClick"
+				Content="{Binding FormBrowser.ExtensionManager, ElementName=ExtraBrowser}"
+				/>
 			<TextBox
 				x:Name="Address"
-				Grid.Column="4"
+				Grid.Column="5"
 				BorderBrush="Gray"
 				BorderThickness="1"
 				FontSize="12"

--- a/Browser/CefSharpBrowser/ExtraBrowser/ExtraBrowserWindow.xaml.cs
+++ b/Browser/CefSharpBrowser/ExtraBrowser/ExtraBrowserWindow.xaml.cs
@@ -45,6 +45,12 @@ public partial class ExtraBrowserWindow
 		Browser.Load(Address.Text);
 	}
 
+	private void ExtensionButtonClick(object sender, RoutedEventArgs e)
+	{
+		Address.Text = "chrome://extensions";
+		Browser.Load(Address.Text);
+	}
+
 	private void ShowDevToolsMenuItemClick(object sender, RoutedEventArgs e)
 	{
 		Browser.ShowDevTools();

--- a/Browser/FormBrowserTranslationViewModel.cs
+++ b/Browser/FormBrowserTranslationViewModel.cs
@@ -78,6 +78,9 @@ public class FormBrowserTranslationViewModel
 	public string Forward => Resources.Forward;
 	public string DmmPoints => Resources.DmmPoints;
 	public string AkashiList => Resources.AkashiList;
+	public string ExtensionManager => Resources.ExtensionManager;
+	public string AddExtension => Resources.AddExtension;
+	public string RemoveExtension => Resources.RemoveExtension;
 
 	public string WebView2NotFound => Resources.WebView2NotFound;
 	public string WebView2DownloadComplete => Resources.WebView2DownloadComplete;

--- a/Browser/Properties/Resources.en.resx
+++ b/Browser/Properties/Resources.en.resx
@@ -364,4 +364,13 @@ Would you like to refresh?</value>
   <data name="FailedToApplyBrowserFont" xml:space="preserve">
     <value>Failed to apply browser font.</value>
   </data>
+  <data name="ExtensionManager" xml:space="preserve">
+    <value>Extension manager</value>
+  </data>
+  <data name="AddExtension" xml:space="preserve">
+    <value>Add extension</value>
+  </data>
+  <data name="RemoveExtension" xml:space="preserve">
+    <value>Remove extension</value>
+  </data>
 </root>

--- a/Browser/Properties/Resources.resx
+++ b/Browser/Properties/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -390,5 +390,14 @@ Microsoft Visual C++ 2019 Redistributableが必要です。
   </data>
   <data name="FailedToApplyBrowserFont" xml:space="preserve">
     <value>ブラウザフォントの適用に失敗しました。</value>
+  </data>
+  <data name="ExtensionManager" xml:space="preserve">
+    <value>??? (Extension manager)</value>
+  </data>
+  <data name="AddExtension" xml:space="preserve">
+    <value>??? (Add extension)</value>
+  </data>
+  <data name="RemoveExtension" xml:space="preserve">
+    <value>??? (Remove extension)</value>
   </data>
 </root>

--- a/Browser/WebView2Browser/Extensions/ExtensionManagerWindow.xaml
+++ b/Browser/WebView2Browser/Extensions/ExtensionManagerWindow.xaml
@@ -1,0 +1,51 @@
+﻿<Window
+	x:Class="Browser.WebView2Browser.Extensions.ExtensionManagerWindow"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:extensions="clr-namespace:Browser.WebView2Browser.Extensions"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ui="http://schemas.modernwpf.com/2019"
+	Title="{Binding FormBrowser.ExtensionManager}"
+	Width="800"
+	Height="600"
+	d:DataContext="{d:DesignInstance extensions:ExtensionManagerViewModel}"
+	ui:WindowHelper.UseModernWindowStyle="True"
+	mc:Ignorable="d"
+	>
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<Grid>
+			<Button Command="{Binding AddExtensionCommand}" Content="{Binding FormBrowser.AddExtension}" />
+		</Grid>
+
+		<DataGrid
+			Grid.Row="1"
+			AutoGenerateColumns="False"
+			HeadersVisibility="Column"
+			IsReadOnly="True"
+			ItemsSource="{Binding Extensions}"
+			MinRowHeight="26"
+			>
+			<DataGrid.Columns>
+				<DataGridTextColumn Binding="{Binding Name}" Header="{Binding DataContext.FormBrowser, RelativeSource={RelativeSource AncestorType=extensions:ExtensionManagerWindow}}" />
+				<DataGridTemplateColumn>
+					<DataGridTemplateColumn.CellTemplate>
+						<DataTemplate>
+							<Button
+								Command="{Binding DataContext.RemoveExtensionCommand, RelativeSource={RelativeSource AncestorType=extensions:ExtensionManagerWindow}}"
+								CommandParameter="{Binding}"
+								Content="{Binding DataContext.FormBrowser.RemoveExtension, RelativeSource={RelativeSource AncestorType=extensions:ExtensionManagerWindow}}"
+								/>
+						</DataTemplate>
+					</DataGridTemplateColumn.CellTemplate>
+				</DataGridTemplateColumn>
+			</DataGrid.Columns>
+		</DataGrid>
+
+	</Grid>
+</Window>

--- a/Browser/WebView2Browser/Extensions/ExtensionManagerWindow.xaml.cs
+++ b/Browser/WebView2Browser/Extensions/ExtensionManagerWindow.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Jot;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace Browser.WebView2Browser.Extensions;
+
+public partial class ExtensionManagerWindow
+{
+	public Tracker Tracker { get; }
+
+	private WebView2 Browser { get; }
+	private ExtensionManagerViewModel ViewModel { get; }
+
+	public ExtensionManagerWindow(WebView2 browser)
+	{
+		Tracker = Ioc.Default.GetRequiredService<Tracker>();
+
+		Browser = browser;
+		ViewModel = new(Browser);
+		DataContext = ViewModel;
+
+		InitializeComponent();
+		ViewModel.InitializeAsync();
+
+		Loaded += (_, _) =>
+		{
+			StartJotTracking();
+		};
+	}
+
+	private void StartJotTracking()
+	{
+		Tracker.Track(this);
+	}
+}

--- a/Browser/WebView2Browser/Extensions/ExtensionViewModel.cs
+++ b/Browser/WebView2Browser/Extensions/ExtensionViewModel.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace Browser.WebView2Browser.Extensions;
+
+public partial class ExtensionManagerViewModel
+{
+	private WebView2 Browser { get; }
+	public FormBrowserTranslationViewModel FormBrowser { get; }
+
+	public ObservableCollection<CoreWebView2BrowserExtension> Extensions { get; } = [];
+
+	public ExtensionManagerViewModel(WebView2 browser)
+	{
+		Browser = browser;
+		FormBrowser = Ioc.Default.GetRequiredService<FormBrowserTranslationViewModel>();
+	}
+
+	public async Task InitializeAsync()
+	{
+		await Browser.EnsureCoreWebView2Async(WebView2ViewModel.Environment);
+
+		await RefreshList();
+	}
+
+	private async Task RefreshList()
+	{
+		Extensions.Clear();
+
+		foreach (CoreWebView2BrowserExtension extension in await Browser.CoreWebView2.Profile.GetBrowserExtensionsAsync())
+		{
+			Extensions.Add(extension);
+		}
+	}
+
+	[RelayCommand]
+	private async Task AddExtension()
+	{
+		System.Windows.Forms.FolderBrowserDialog folderBrowserDialog = new()
+		{
+			RootFolder = Environment.SpecialFolder.Desktop,
+		};
+
+		if (folderBrowserDialog.ShowDialog() is not System.Windows.Forms.DialogResult.OK) return;
+
+		try
+		{
+			await Browser.CoreWebView2.Profile.AddBrowserExtensionAsync(folderBrowserDialog.SelectedPath);
+			await RefreshList();
+		}
+		catch (Exception ex)
+		{
+			MessageBox.Show(ex.Message, FormBrowser.Title, MessageBoxButton.OK, MessageBoxImage.Error);
+		}
+	}
+
+	[RelayCommand]
+	private async Task RemoveExtension(CoreWebView2BrowserExtension extension)
+	{
+		try
+		{
+			await extension.RemoveAsync();
+			await RefreshList();
+		}
+		catch (Exception ex)
+		{
+			MessageBox.Show(ex.Message, FormBrowser.Title, MessageBoxButton.OK, MessageBoxImage.Error);
+		}
+	}
+}

--- a/Browser/WebView2Browser/ExtraBrowser/ExtraBrowserWindow.xaml
+++ b/Browser/WebView2Browser/ExtraBrowser/ExtraBrowserWindow.xaml
@@ -41,6 +41,7 @@
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition />
 			</Grid.ColumnDefinitions>
 			<Button
@@ -65,9 +66,14 @@
 				Click="AkashiListButtonClick"
 				Content="{Binding FormBrowser.AkashiList, ElementName=ExtraBrowser}"
 				/>
+			<Button
+				Grid.Column="4"
+				Click="ExtensionButtonClick"
+				Content="{Binding FormBrowser.ExtensionManager, ElementName=ExtraBrowser}"
+				/>
 			<TextBox
 				x:Name="txtBoxAddress"
-				Grid.Column="4"
+				Grid.Column="5"
 				BorderBrush="Gray"
 				BorderThickness="1"
 				FontSize="12"

--- a/Browser/WebView2Browser/ExtraBrowser/ExtraBrowserWindow.xaml.cs
+++ b/Browser/WebView2Browser/ExtraBrowser/ExtraBrowserWindow.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using Browser.WebView2Browser.Extensions;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Jot;
 using Microsoft.Web.WebView2.Core;
@@ -104,6 +106,11 @@ public partial class ExtraBrowserWindow : Window
 		txtBoxAddress.Text = "https://akashi-list.me/";
 	}
 
+	private void ExtensionButtonClick(object sender, RoutedEventArgs e)
+	{
+		ExtensionManagerWindow view = new(Browser);
+		view.ShowDialog();
+	}
 
 	private void ShowDevToolsMenuItemClick(object sender, RoutedEventArgs e)
 	{

--- a/Browser/WebView2Browser/WebView2ViewModel.cs
+++ b/Browser/WebView2Browser/WebView2ViewModel.cs
@@ -221,8 +221,10 @@ public class WebView2ViewModel : BrowserViewModel
 
 		var corewebviewoptions = new CoreWebView2EnvironmentOptions
 		{
-			AdditionalBrowserArguments = string.Join(" ", browserArgs)
+			AdditionalBrowserArguments = string.Join(" ", browserArgs),
+			AreBrowserExtensionsEnabled = true,
 		};
+
 		var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder: BrowserCachePath, options: corewebviewoptions);
 
 		Environment = env;


### PR DESCRIPTION
Had to handle Cefsharp and Webview2 differently : 

Cefsharp : 
Cefsharp had support for extensions but was buggy. In newer version, they dropped extension support.
But you can manually add extension with Chrome's built-in extension manager.
So in extra browser, I added a button that opens chrome's extension page.

![image](https://github.com/user-attachments/assets/8c77e50a-7f19-4f53-abf6-2f594ddb1bfd)

Webview2 : 
Webview2 supports extensions programmatically, but the user can't manage his extensions.
I added a button that opens a simple view that behaves like chrome's extension page in extra browser.

![image](https://github.com/user-attachments/assets/da043fbd-78c0-49d4-b2a8-07eae426909d)
