### PR TITLE
Air base sparkles

### DIFF
--- a/ElectronicObserver.KancolleApi.Types/Models/APIPlaneInfo.cs
+++ b/ElectronicObserver.KancolleApi.Types/Models/APIPlaneInfo.cs
@@ -1,9 +1,11 @@
-﻿namespace ElectronicObserver.KancolleApi.Types.Models;
+﻿using ElectronicObserverTypes;
+
+namespace ElectronicObserver.KancolleApi.Types.Models;
 
 public class ApiPlaneInfo
 {
 	[JsonPropertyName("api_cond")]
-	public int? ApiCond { get; set; }
+	public AirBaseCondition? ApiCond { get; set; }
 
 	[JsonPropertyName("api_count")]
 	public int? ApiCount { get; set; }

--- a/ElectronicObserver/Data/BaseAirCorpsSquadron.cs
+++ b/ElectronicObserver/Data/BaseAirCorpsSquadron.cs
@@ -61,7 +61,7 @@ public class BaseAirCorpsSquadron : APIWrapper, IIdentifiable, IBaseAirCorpsSqua
 	/// コンディション
 	/// 1=通常、2=橙疲労、3=赤疲労
 	/// </summary>
-	public int Condition => RawData.api_cond() ? (int)RawData.api_cond : 1;
+	public AirBaseCondition Condition => RawData.api_cond() ? (AirBaseCondition)RawData.api_cond : AirBaseCondition.Sparkled;
 
 
 

--- a/ElectronicObserver/Data/TsunDbSubmission/Battle/TsunDbBattleLBASData.cs
+++ b/ElectronicObserver/Data/TsunDbSubmission/Battle/TsunDbBattleLBASData.cs
@@ -39,7 +39,7 @@ public class TsunDbBattleLBASData : TsunDbEntity
 	/// Array of plane morale for each plane in the base pre-sortie
 	/// </summary>
 	[JsonPropertyName("morale")]
-	public List<int> PlaneMorale { get; }
+	public List<AirBaseCondition> PlaneMorale { get; }
 
 	/// <summary>
 	/// Array of int[2] of edges targeted by the land base

--- a/ElectronicObserver/Database/Sortie/SortieAirBaseSquadron.cs
+++ b/ElectronicObserver/Database/Sortie/SortieAirBaseSquadron.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using ElectronicObserverTypes;
 
 namespace ElectronicObserver.Database.Sortie;
 
@@ -11,7 +12,7 @@ public class SortieAirBaseSquadron
 	public int State { get; set; }
 
 	[JsonPropertyName("Condition")]
-	public int Condition { get; set; }
+	public AirBaseCondition Condition { get; set; }
 
 	[JsonPropertyName("EquipmentSlot")]
 	public SortieEquipmentSlot EquipmentSlot { get; set; } = new();

--- a/ElectronicObserver/Notifier/NotifierBaseAirCorps.cs
+++ b/ElectronicObserver/Notifier/NotifierBaseAirCorps.cs
@@ -154,7 +154,7 @@ public class NotifierBaseAirCorps : NotifierBase
 		{
 			if (NotifiesNotSupplied && corps.Squadrons.Values.Any(sq => sq.State == 1 && sq.AircraftCurrent < sq.AircraftMax))
 				messages.AddLast(FleetRes.SupplyNeeded);
-			if (NotifiesTired && corps.Squadrons.Values.Any(sq => sq.State == 1 && sq.Condition > 1))
+			if (NotifiesTired && corps.Squadrons.Values.Any(sq => sq is { State: 1, Condition: > AirBaseCondition.Normal }))
 				messages.AddLast(FleetRes.Fatigued);
 			if (NotifiesNotOrganized)
 			{

--- a/ElectronicObserver/Window/GeneralRes.en.resx
+++ b/ElectronicObserver/Window/GeneralRes.en.resx
@@ -845,4 +845,7 @@ Please click here to restart.</value>
   <data name="NextAsw" xml:space="preserve">
     <value>Next ASW</value>
   </data>
+  <data name="MaximumMorale" xml:space="preserve">
+    <value>Maximum morale</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/GeneralRes.resx
+++ b/ElectronicObserver/Window/GeneralRes.resx
@@ -844,4 +844,7 @@
   <data name="NextAsw" xml:space="preserve">
     <value>次の対潜</value>
   </data>
+  <data name="MaximumMorale" xml:space="preserve">
+    <value>士気最大</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/DataExport/DataExportHelper.cs
@@ -1081,7 +1081,7 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 		Name = squadron?.EquipmentInstance?.Name,
 		Level = squadron?.EquipmentInstance?.Level,
 		AircraftLevel = squadron?.EquipmentInstance?.AircraftLevel,
-		Condition = AirBaseCondition(squadron?.Condition),
+		Condition = AirBaseConditionDisplay(squadron?.Condition),
 		Aircraft = squadron?.AircraftCurrent,
 	};
 
@@ -1292,12 +1292,12 @@ public class DataExportHelper(ElectronicObserverContext db, ToolService toolServ
 		_ => $"不明({kind})",
 	};
 
-	private static string? AirBaseCondition(int? condition) => condition switch
+	private static string? AirBaseConditionDisplay(AirBaseCondition? condition) => condition switch
 	{
 		null => null,
-		1 => "通常",
-		2 => "橙疲労",
-		3 => "赤疲労",
-		int cond => $"不明({cond})",
+		AirBaseCondition.Normal => "通常",
+		AirBaseCondition.Tired => "橙疲労",
+		AirBaseCondition.VeryTired => "赤疲労",
+		AirBaseCondition cond => $"不明({(int)cond})",
 	};
 }

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/Replay/ReplayAirBaseSquadron.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/Replay/ReplayAirBaseSquadron.cs
@@ -21,5 +21,5 @@ public class ReplayAirBaseSquadron
 	public int State { get; set; }
 
 	[JsonPropertyName("morale")]
-	public int Morale { get; set; }
+	public AirBaseCondition Morale { get; set; }
 }

--- a/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsItemViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsItemViewModel.cs
@@ -91,22 +91,32 @@ public class BaseAirCorpsItemViewModel : ObservableObject
 			// state
 
 			// 疲労
-			int tired = corps.Squadrons.Values.Max(sq => sq?.Condition ?? 0);
+			AirBaseCondition tired = corps.Squadrons.Values.Any(s => s.State is 1) switch
+			{
+				true => corps.Squadrons.Values
+					.Max(sq => sq?.Condition ?? AirBaseCondition.Sparkled),
+				_ => AirBaseCondition.Normal,
+			};
 
 			Name.ConditionIcon = tired switch
 			{
-				3 => IconContent.ConditionVeryTired,
-				2 => IconContent.ConditionTired,
+				AirBaseCondition.VeryTired => IconContent.ConditionVeryTired,
+				AirBaseCondition.Tired => IconContent.ConditionTired,
+				AirBaseCondition.Sparkled => IconContent.ConditionSparkle,
 				_ => null,
 			};
 
 			switch (tired)
 			{
-				case 2:
+				case AirBaseCondition.Sparkled:
+					// todo I guess?
+					break;
+
+				case AirBaseCondition.Tired:
 					sb.AppendLine(GeneralRes.Tired);
 					break;
 
-				case 3:
+				case AirBaseCondition.VeryTired:
 					sb.AppendLine(GeneralRes.VeryTired);
 					break;
 			}
@@ -241,14 +251,20 @@ public class BaseAirCorpsItemViewModel : ObservableObject
 
 					switch (squadron.Condition)
 					{
-						case 1:
-						default:
+						case AirBaseCondition.Sparkled:
+							// todo I guess?
 							break;
-						case 2:
+
+						case AirBaseCondition.Tired:
 							sb.Append("[" + GeneralRes.Tired + "] ");
 							break;
-						case 3:
+
+						case AirBaseCondition.VeryTired:
 							sb.Append("[" + GeneralRes.VeryTired + "] ");
+							break;
+
+						case AirBaseCondition.Normal:
+						default:
 							break;
 					}
 

--- a/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsItemViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsItemViewModel.cs
@@ -91,14 +91,14 @@ public class BaseAirCorpsItemViewModel : ObservableObject
 			// state
 
 			// 疲労
-			AirBaseCondition tired = corps.Squadrons.Values.Any(s => s.State is 1) switch
+			AirBaseCondition condition = corps.Squadrons.Values.Any(s => s.State is 1) switch
 			{
 				true => corps.Squadrons.Values
 					.Max(sq => sq?.Condition ?? AirBaseCondition.Sparkled),
 				_ => AirBaseCondition.Normal,
 			};
 
-			Name.ConditionIcon = tired switch
+			Name.ConditionIcon = condition switch
 			{
 				AirBaseCondition.VeryTired => IconContent.ConditionVeryTired,
 				AirBaseCondition.Tired => IconContent.ConditionTired,
@@ -106,10 +106,10 @@ public class BaseAirCorpsItemViewModel : ObservableObject
 				_ => null,
 			};
 
-			switch (tired)
+			switch (condition)
 			{
 				case AirBaseCondition.Sparkled:
-					// todo I guess?
+					sb.AppendLine(GeneralRes.MaximumMorale);
 					break;
 
 				case AirBaseCondition.Tired:
@@ -252,15 +252,15 @@ public class BaseAirCorpsItemViewModel : ObservableObject
 					switch (squadron.Condition)
 					{
 						case AirBaseCondition.Sparkled:
-							// todo I guess?
+							sb.Append($"[{GeneralRes.MaximumMorale}] ");
 							break;
 
 						case AirBaseCondition.Tired:
-							sb.Append("[" + GeneralRes.Tired + "] ");
+							sb.Append($"[{GeneralRes.Tired}] ");
 							break;
 
 						case AirBaseCondition.VeryTired:
-							sb.Append("[" + GeneralRes.VeryTired + "] ");
+							sb.Append($"[{GeneralRes.VeryTired}] ");
 							break;
 
 						case AirBaseCondition.Normal:

--- a/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsViewModel.cs
@@ -94,14 +94,18 @@ public partial class BaseAirCorpsViewModel : AnchorableViewModel
 			.ToList();
 
 		bool isNotReplenished = squadrons.Any(s => s.State == 1 && s.AircraftCurrent < s.AircraftMax);
-		bool isTired = squadrons.Any(s => s is { State: 1, Condition: 2 });
-		bool isVeryTired = squadrons.Any(s => s is { State: 1, Condition: 3 });
+		bool isTired = squadrons.Any(s => s is { State: 1, Condition: AirBaseCondition.Tired });
+		bool isVeryTired = squadrons.Any(s => s is { State: 1, Condition: AirBaseCondition.VeryTired });
+		bool isAllSparkled = squadrons.Any() && squadrons
+			.Where(s => s.State is 1)
+			.All(s => s.Condition is AirBaseCondition.Sparkled);
 
 		Icon = true switch
 		{
 			_ when isNotReplenished => IconContent.FleetNotReplenished,
 			_ when isVeryTired => IconContent.ConditionVeryTired,
 			_ when isTired => IconContent.ConditionTired,
+			_ when isAllSparkled => IconContent.ConditionSparkle,
 			_ => IconContent.FormBaseAirCorps,
 		};
 	}

--- a/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/BaseAirCorps/BaseAirCorpsViewModel.cs
@@ -96,7 +96,7 @@ public partial class BaseAirCorpsViewModel : AnchorableViewModel
 		bool isNotReplenished = squadrons.Any(s => s.State == 1 && s.AircraftCurrent < s.AircraftMax);
 		bool isTired = squadrons.Any(s => s is { State: 1, Condition: AirBaseCondition.Tired });
 		bool isVeryTired = squadrons.Any(s => s is { State: 1, Condition: AirBaseCondition.VeryTired });
-		bool isAllSparkled = squadrons.Any() && squadrons
+		bool isAllSparkled = squadrons.Count > 0 && squadrons
 			.Where(s => s.State is 1)
 			.All(s => s.Condition is AirBaseCondition.Sparkled);
 

--- a/ElectronicObserverTypes/AirBaseCondition.cs
+++ b/ElectronicObserverTypes/AirBaseCondition.cs
@@ -1,0 +1,9 @@
+﻿namespace ElectronicObserverTypes;
+
+public enum AirBaseCondition
+{
+	Sparkled = 0,
+	Normal = 1,
+	Tired = 2,
+	VeryTired = 3,
+}

--- a/ElectronicObserverTypes/IBaseAirCorpsSquadron.cs
+++ b/ElectronicObserverTypes/IBaseAirCorpsSquadron.cs
@@ -49,7 +49,7 @@ public interface IBaseAirCorpsSquadron
 	/// コンディション
 	/// 1=通常、2=橙疲労、3=赤疲労
 	/// </summary>
-	int Condition { get; }
+	AirBaseCondition Condition { get; }
 
 	/// <summary>
 	/// 配置転換を開始した時刻

--- a/ElectronicObserverTypes/Mocks/BaseAirCorpsSquadronMock.cs
+++ b/ElectronicObserverTypes/Mocks/BaseAirCorpsSquadronMock.cs
@@ -13,7 +13,7 @@ public class BaseAirCorpsSquadronMock : IBaseAirCorpsSquadron
 	public IEquipmentDataMaster? EquipmentInstanceMaster { get; set; }
 	public int AircraftCurrent { get; set; }
 	public int AircraftMax { get; set; }
-	public int Condition { get; set; } = 49;
+	public AirBaseCondition Condition { get; set; } = AirBaseCondition.Normal;
 	public DateTime RelocatedTime { get; set; }
 	public int ID { get; set; }
 	public bool IsAvailable { get; set; }


### PR DESCRIPTION
Tried to make the logic the same as fleets
Empty (state = 0) AB slots and planes that are being moved (state = 2) are treated as the same, I'll be calling them both "empty" here.
If all slots are empty, no morale icon.
If all non-empty slots are sparkled, sparkled icon for that AB.
If all AB are sparkled, the AB view uses a sparkle icon.

todo: need to add new text stuff, will do that when I wake up