### PR TITLE
fix sounds

### DIFF
--- a/ElectronicObserver/Notifier/NotifierBase.cs
+++ b/ElectronicObserver/Notifier/NotifierBase.cs
@@ -143,7 +143,6 @@ public abstract class NotifierBase
 	{
 		try
 		{
-
 			DisposeSound();
 
 			if (File.Exists(path))

--- a/ElectronicObserver/Utility/EOMediaPlayer.cs
+++ b/ElectronicObserver/Utility/EOMediaPlayer.cs
@@ -66,8 +66,11 @@ public class EOMediaPlayer
 		{
 			if (AudioFile?.FileName != value && !string.IsNullOrEmpty(value))
 			{
-				AudioFile = new(value);
-				AudioFile.Volume = NormalizedInternalVolume;
+				AudioFile = new(value)
+				{
+					Volume = NormalizedInternalVolume
+				};
+
 				MediaPlayer.Init(AudioFile);
 			}
 		}

--- a/ElectronicObserver/Utility/EOMediaPlayer.cs
+++ b/ElectronicObserver/Utility/EOMediaPlayer.cs
@@ -66,6 +66,8 @@ public class EOMediaPlayer
 		{
 			if (AudioFile?.FileName != value && !string.IsNullOrEmpty(value))
 			{
+				Close();
+
 				AudioFile = new(value)
 				{
 					Volume = NormalizedInternalVolume

--- a/ElectronicObserver/Utility/EOMediaPlayer.cs
+++ b/ElectronicObserver/Utility/EOMediaPlayer.cs
@@ -67,11 +67,25 @@ public class EOMediaPlayer
 			if (AudioFile?.FileName != value && !string.IsNullOrEmpty(value))
 			{
 				AudioFile = new(value);
+				AudioFile.Volume = NormalizedInternalVolume;
 				MediaPlayer.Init(AudioFile);
 			}
 		}
 	}
 
+	/// <summary>
+	/// Mute sets volume to 0, this property tracks the actual volume.
+	/// </summary>
+	private int InternalVolume { get; set; }
+
+	/// <summary>
+	/// For setting the AudioFile volume value.
+	/// </summary>
+	private float NormalizedInternalVolume => IsMute switch
+	{
+		true => 0,
+		_ => (float)InternalVolume / 100,
+	};
 
 	/// <summary>
 	/// 音量
@@ -80,8 +94,16 @@ public class EOMediaPlayer
 	/// </summary>
 	public int Volume
 	{
-		get => (int)(MediaPlayer.Volume * 100);
-		set => MediaPlayer.Volume = (float)value / 100;
+		get => InternalVolume;
+		set
+		{
+			InternalVolume = value;
+
+			if (AudioFile is not null)
+			{
+				AudioFile.Volume = NormalizedInternalVolume;
+			}
+		}
 	}
 
 	/// <summary>
@@ -89,31 +111,14 @@ public class EOMediaPlayer
 	/// </summary>
 	public bool IsMute
 	{
-		get
-		{
-			try
-			{
-
-				uint id = (uint)Environment.ProcessId;
-				return BrowserLibCore.VolumeManager.GetApplicationMute(id);
-			}
-			catch
-			{
-				// this logic needs to get reworked anyway
-			}
-
-			return false;
-		}
+		get;
 		set
 		{
-			try
+			field = value;
+
+			if (AudioFile is not null)
 			{
-				uint id = (uint)Environment.ProcessId;
-				BrowserLibCore.VolumeManager.SetApplicationMute(id, value);
-			}
-			catch
-			{
-				// this logic needs to get reworked anyway
+				AudioFile.Volume = NormalizedInternalVolume;
 			}
 		}
 	}

--- a/ElectronicObserver/Window/Settings/Notification/Base/ConfigurationNotificationBaseViewModel.cs
+++ b/ElectronicObserver/Window/Settings/Notification/Base/ConfigurationNotificationBaseViewModel.cs
@@ -41,14 +41,14 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 	[ObservableProperty]
 	[NotifyDataErrorInfo]
 	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateImagePath))]
-	public partial string ImagePath { get; set; }
+	public partial string ImagePath { get; set; } = "";
 
 	public bool DrawsImage { get; set; }
 
 	[ObservableProperty]
 	[NotifyDataErrorInfo]
 	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateSoundPath))]
-	public partial string SoundPath { get; set; }
+	public partial string SoundPath { get; set; } = "";
 
 	[ObservableProperty]
 	[NotifyDataErrorInfo]

--- a/ElectronicObserver/Window/Settings/Notification/Base/ConfigurationNotificationBaseViewModel.cs
+++ b/ElectronicObserver/Window/Settings/Notification/Base/ConfigurationNotificationBaseViewModel.cs
@@ -11,14 +11,12 @@ using ElectronicObserver.Common;
 using ElectronicObserver.Notifier;
 using ElectronicObserver.Services;
 using ElectronicObserver.Utility;
-using ElectronicObserver.Window.Dialog;
 
 namespace ElectronicObserver.Window.Settings.Notification.Base;
 
 public partial class ConfigurationNotificationBaseViewModel : ObservableValidator
 {
 	public ConfigurationNotificationBaseTranslationViewModel Translation { get; }
-	private FileService FileService { get; }
 
 	private Configuration.ConfigurationData.ConfigNotifierBase Config { get; }
 	protected virtual NotifierBase NotifierBase { get; }
@@ -26,25 +24,36 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 	public List<CheckBoxEnumViewModel> ClickFlags { get; }
 	public List<NotifierDialogAlignment> DialogAlignments { get; }
 
-	public bool IsEnabled { get; set; }
+	public bool IsLoading { get; set; }
 
-	public bool IsSilenced { get; set; }
+	[ObservableProperty]
+	[NotifyDataErrorInfo]
+	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateSoundPath))]
+	public partial bool IsEnabled { get; set; }
+
+	[ObservableProperty]
+	[NotifyDataErrorInfo]
+	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateSoundPath))]
+	public partial bool IsSilenced { get; set; }
 
 	public bool ShowsDialog { get; set; }
 
 	[ObservableProperty]
 	[NotifyDataErrorInfo]
 	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateImagePath))]
-	private string _imagePath;
+	public partial string ImagePath { get; set; }
 
 	public bool DrawsImage { get; set; }
 
 	[ObservableProperty]
 	[NotifyDataErrorInfo]
 	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateSoundPath))]
-	private string _soundPath;
+	public partial string SoundPath { get; set; }
 
-	public bool PlaysSound { get; set; }
+	[ObservableProperty]
+	[NotifyDataErrorInfo]
+	[CustomValidation(typeof(ConfigurationNotificationBaseViewModel), nameof(ValidateSoundPath))]
+	public partial bool PlaysSound { get; set; }
 
 	public int SoundVolume { get; set; }
 
@@ -76,7 +85,11 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 
 	public Color BackColor { get; set; }
 
-	private bool SoundChanged => SoundPath != Config.SoundPath;
+	private bool SoundChanged =>
+		SoundPath != Config.SoundPath ||
+		IsEnabled != Config.IsEnabled ||
+		IsSilenced != Config.IsSilenced ||
+		PlaysSound != Config.PlaysSound;
 
 	private bool ImageChanged => ImagePath != Config.ImagePath;
 
@@ -85,7 +98,6 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 		NotifierBase notifier)
 	{
 		Translation = Ioc.Default.GetRequiredService<ConfigurationNotificationBaseTranslationViewModel>();
-		FileService = Ioc.Default.GetRequiredService<FileService>();
 
 		ClickFlags = Enum.GetValues<NotifierDialogClickFlags>()
 			.Where(f => f is not (NotifierDialogClickFlags.None or NotifierDialogClickFlags.HighestBit))
@@ -111,6 +123,8 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 
 	public virtual void Load()
 	{
+		IsLoading = true;
+
 		IsEnabled = NotifierBase.IsEnabled;
 		IsSilenced = NotifierBase.IsSilenced;
 		ShowsDialog = NotifierBase.ShowsDialog;
@@ -137,6 +151,8 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 		{
 			clickFlag.IsChecked = NotifierBase.DialogData.ClickFlag.HasFlag(clickFlag.Value);
 		}
+
+		IsLoading = false;
 	}
 
 	public bool TrySaveConfiguration()
@@ -205,6 +221,8 @@ public partial class ConfigurationNotificationBaseViewModel : ObservableValidato
 		{
 			throw new NotImplementedException();
 		}
+
+		if (viewModel.IsLoading) return ValidationResult.Success!;
 
 		return (viewModel.SoundChanged && !viewModel.NotifierBase.LoadSound(viewModel.SoundPath) && viewModel.PlaysSound) switch
 		{


### PR DESCRIPTION
The mute sync with browser for BGM player will now only mute the BGM player instead of the whole app - notification sounds will still work.

Fixed a bug where if you already set a sound path for notifications but had sound disabled, the music wouldn't load when enabling it and trying to test/play it.
![image](https://github.com/user-attachments/assets/2425bab2-a9da-4663-9825-197578ffd814)
