### PR TITLE
rework browser refresh

### DIFF
--- a/Browser/CefSharpBrowser/CefSharpViewModel.cs
+++ b/Browser/CefSharpBrowser/CefSharpViewModel.cs
@@ -373,9 +373,18 @@ public class CefSharpViewModel : BrowserViewModel
 
 	protected override void RefreshBrowser() => RefreshBrowser(false);
 
-	protected override void RefreshBrowser(bool ignoreCache)
+	protected override async void RefreshBrowser(bool ignoreCache)
 	{
-		CefSharp?.Reload(ignoreCache);
+		if (CefSharp is null) return;
+
+		string address = CefSharp.Address;
+		await CefSharp.LoadUrlAsync("about:blank");
+		await CefSharp.LoadUrlAsync(address);
+
+		if (ignoreCache)
+		{
+			CefSharp.Reload(ignoreCache);
+		}
 	}
 
 	protected override void Exit()

--- a/Browser/WebView2Browser/WebView2ViewModel.cs
+++ b/Browser/WebView2Browser/WebView2ViewModel.cs
@@ -486,20 +486,21 @@ public class WebView2ViewModel : BrowserViewModel
 	/// ブラウザを再読み込みします。
 	/// </summary>
 	/// <param name="ignoreCache">キャッシュを無視するか。</param>
-	protected override void RefreshBrowser(bool ignoreCache)
+	protected override async void RefreshBrowser(bool ignoreCache)
 	{
 		if (WebView2 is null) return;
+		if (DevToolsHelper is null) return;
+
+		IsRefreshing = true;
+
+		string address = WebView2.CoreWebView2.Source;
+		await DevToolsHelper.Page.NavigateAsync("about:blank");
+		await DevToolsHelper.Page.NavigateAsync(address);
 
 		if (ignoreCache)
 		{
 			DevToolsHelper.Page.ReloadAsync(true);
 		}
-		else
-		{
-			WebView2.CoreWebView2.Reload();
-		}
-
-		IsRefreshing = true;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Refresh is changed to:
- Navigate to about:blank (instant)
- Navigate to the previous address (can take a few seconds)

This fixes the problem of DMM taking a few seconds to process the refresh, which might cause a failed F5 cheese.